### PR TITLE
(#1) refresh-token 설정 제거, access-token 유효기간 설정, 로그아웃 뷰 구현

### DIFF
--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -4,6 +4,7 @@ from account import views
 urlpatterns = [
     # Auth related
     path('login/', views.UserLogin.as_view(), name='login'),
+    path('logout/', views.UserLogout.as_view(), name='logout'),
     path('signup/email/', views.UserEmailCheck.as_view(), name='user-email-check'),
     path('signup/password/', views.UserPasswordCheck.as_view(), name='user-password-check'),
     path('signup/username/', views.UserUsernameCheck.as_view(), name='user-username-check'),

--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -1,7 +1,4 @@
 from django.urls import path
-from django.views.decorators.csrf import ensure_csrf_cookie
-from rest_framework_simplejwt.views import TokenRefreshView, TokenVerifyView
-
 from account import views
 
 urlpatterns = [

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -4,7 +4,6 @@ import json
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth import get_user_model, authenticate, logout
-from django.contrib.auth.models import update_last_login
 from django.core import exceptions
 from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
@@ -81,9 +80,6 @@ class UserLogin(APIView):
                 samesite = settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE']
             )
             csrf.get_token(request)
-            return response
-            if api_settings.UPDATE_LAST_LOGIN:
-                update_last_login(None, user)
             return response
         else:
             raise WrongPassword()

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -3,7 +3,7 @@ import json
 
 from django.apps import apps
 from django.conf import settings
-from django.contrib.auth import get_user_model, authenticate
+from django.contrib.auth import get_user_model, authenticate, logout
 from django.contrib.auth.models import update_last_login
 from django.core import exceptions
 from django.contrib.auth import get_user_model
@@ -87,8 +87,16 @@ class UserLogin(APIView):
             return response
         else:
             raise WrongPassword()
-        
-        
+
+
+class UserLogout(APIView):
+    def get(self, request):
+        logout(request)
+        response = Response()
+        response.delete_cookie(settings.SIMPLE_JWT['AUTH_COOKIE'])
+        return response
+    
+
 class UserEmailCheck(generics.CreateAPIView):
     serializer_class = UserEmailSerializer
     parser_classes = (MultiPartParser, FormParser)

--- a/adoorback/adoorback/settings/base.py
+++ b/adoorback/adoorback/settings/base.py
@@ -48,39 +48,13 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    # NOTE: 브라우저, 앱의 쿠키 expire 설정도 해줘야 함
-    'ACCESS_TOKEN_LIFETIME': timedelta(days=7),
-    'REFRESH_TOKEN_LIFETIME': timedelta(days=30),
-    'ROTATE_REFRESH_TOKENS': True,
-    'BLACKLIST_AFTER_ROTATION': True,
-
-    'ALGORITHM': 'HS256',
-    'SIGNING_KEY': SECRET_KEY,
-    'VERIFYING_KEY': None,
-    'AUDIENCE': None,
-    'ISSUER': None,
-
-    'AUTH_HEADER_TYPES': ('Bearer',),
-    'AUTH_HEADER_NAME': 'HTTP_AUTHORIZATION',
-    'USER_ID_FIELD': 'id',
-    'USER_ID_CLAIM': 'user_id',
-    'USER_AUTHENTICATION_RULE': 'rest_framework_simplejwt.authentication.default_user_authentication_rule',
-
-    'AUTH_TOKEN_CLASSES': ('rest_framework_simplejwt.tokens.AccessToken',),
-    'TOKEN_TYPE_CLAIM': 'token_type',
-
-    'JTI_CLAIM': 'jti',
-
-    'SLIDING_TOKEN_REFRESH_EXP_CLAIM': 'refresh_exp',
-    'SLIDING_TOKEN_LIFETIME': timedelta(days=7),
-    'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=30),
-
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=365),
+    
     # custom
     'AUTH_COOKIE': 'access_token',  # Cookie name. Enables cookies if value is set.
-    'AUTH_COOKIE_DOMAIN': None,     # A string like "example.com", or None for standard domain cookie.
+    'AUTH_COOKIE_MAX_AGE': 60 * 60 * 24 * 365, # access token cookie max age. same as JWT ACCESS_TOKEN_LIFETIME.
     'AUTH_COOKIE_SECURE': False,
     'AUTH_COOKIE_HTTP_ONLY' : True,
-    'AUTH_COOKIE_PATH': '/',        # The path of the auth cookie.
     'AUTH_COOKIE_SAMESITE': 'Lax',  # Whether to set the flag restricting cookie leaks on cross-site requests. This can be 'Lax', 'Strict', or None to disable the flag.
 }
 


### PR DESCRIPTION
## Issue Number: #1, GooJinSun/WhoAmI-Today-frontend#4

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 사용하지 않는 simple-jwt의 refresh 토큰 관련 설정 제거(b98f5a4)
  - 혹시 잘못 삭제한 설정이 있다면 코멘트 부탁드려요!
  - refresh token도 쿠키에 담게 되면 access_token을 계속해서 무한 연장할 수 있는 문제가 있어 삭제하고, 아래와 같이 access_token을 담은 쿠키의 유효 기간을 설정하도록 했습니다([참고: JWT를 이용한 로그인에서 보안을 높이는 방법(HTTPS, Cookie)](https://velog.io/@hyehyeonmoon/%EB%8F%99%EA%B8%80-JWT%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EB%A1%9C%EA%B7%B8%EC%9D%B8%EC%97%90%EC%84%9C-%EB%B3%B4%EC%95%88%EC%9D%84-%EB%86%92%EC%9D%B4%EB%8A%94-%EB%B0%A9%EB%B2%95HTTPS-Cookie))
- access_token의 유효기간이 올바르게(일단 1년으로) 설정될 수 있도록 수정(b98f5a4)
  - expires가 datetime object로 설정되면, max-age가 있어야 하는데 없어서 session으로 설정되고 있었습니다([참고](https://docs.djangoproject.com/en/4.2/ref/request-response/#django.http.HttpResponse.set_cookie))
- logout시에 access_token을 제거하도록 뷰? 추가(4237487)

## Preview Image

## Further comments
장고 코드에 익숙하지 않아서 잘못 작성된 코드가 있을 수도 있을 것 같아요! 확인 부탁드립니다~