### PR TITLE
(#48) [Bug] 계정 삭제 이후, 해당 계정의 access_token 쿠키 삭제 필요 

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -276,6 +276,7 @@ class UserList(generics.ListAPIView):
             queryset = User.objects.all()
         return queryset
 
+
 class CurrentUserDelete(generics.DestroyAPIView):
     serializer_class = UserProfileSerializer
     permission_classes = [IsAuthenticated]
@@ -293,6 +294,14 @@ class CurrentUserDelete(generics.DestroyAPIView):
         instance.save()
         # user is soft-deleted, contents user created will be cascade-deleted
         instance.delete(force_policy=SOFT_DELETE_CASCADE)
+
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        self.perform_destroy(instance)
+        response = Response(status=status.HTTP_204_NO_CONTENT)
+        response.delete_cookie(settings.SIMPLE_JWT['AUTH_COOKIE'])
+        return response
+
 
 class CurrentUserFriendList(generics.ListAPIView):
     serializer_class = AuthorFriendSerializer


### PR DESCRIPTION
## Issue Number: #48 

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
계정 삭제 이후에도 기존 계정의 access token 쿠키가 남아있어 다음 로그인이나 회원가입이 불가한 이슈가 발견되었습니다. (thanks to @GooJinSun )
따라서 계정 삭제 API 에서 access token 쿠키를 삭제하도록 수정하였습니다.

## Preview Image

## Further comments
