### PR TITLE
(#58) 친구 요청 상태 필드 버그 수정

### DIFF
--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -169,11 +169,11 @@ class UserFriendshipStatusSerializer(AuthorFriendSerializer):
 
     def get_received_friend_request_from(self, obj):
         return self.context.get('request', None).user.id in \
-               list(obj.sent_friend_requests.values_list('requestee_id', flat=True))
+               list(obj.sent_friend_requests.filter(accepted__isnull=True).values_list('requestee_id', flat=True))
 
     def get_sent_friend_request_to(self, obj):
         return self.context.get('request', None).user.id in \
-               list(obj.received_friend_requests.values_list('requester_id', flat=True))
+               list(obj.received_friend_requests.exclude(accepted=True).values_list('requester_id', flat=True))
 
     def get_are_friends(self, obj):
         user = self.context.get('request', None).user

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -396,7 +396,7 @@ class UserFriendRequestList(generics.ListCreateAPIView):
         return adoor_exception_handler
 
     def get_queryset(self):
-        return FriendRequest.objects.filter(requestee=self.request.user)
+        return FriendRequest.objects.filter(requestee=self.request.user).filter(accepted__isnull=True)
 
     @transaction.atomic
     def perform_create(self, serializer):


### PR DESCRIPTION
## Issue Number: #58

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- `api/user/profile/<username>/ `API에서,
  - `received_friend_request_from` 필드
    - AS-IS: 친구요청을 수락/거절한 경우에도 해당 필드가 `true`로 반환됨
    - TO-BE: 친구 요청에 답하지 않은 경우 `true`, 수락 혹은 거절한 경우 `false`로 반환됨
  - `sent_friend_request_to` 필드
    - AS-IS: 친구요청이 수락된 경우에도 해당 필드가 `true`로 반환됨
    - TO-BE: 친구 요청이 수락된 경우 `true`, 거절당했거나 대기중인 경우 `false`로 반환됨

