### PR TITLE
(#177) friend chat room ID API

### DIFF
--- a/adoorback/chat/urls.py
+++ b/adoorback/chat/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('rooms/', views.ChatRoomList.as_view()),
     path('rooms/<int:pk>/', views.ChatRoomFriendList.as_view()),
     path('<int:pk>/messages/', views.ChatMessagesListView.as_view()),
+    path('rooms/one_on_one/<int:pk>/', views.OneOnOneChatRoomId.as_view()),
 ]


### PR DESCRIPTION
## Issue Number: #177

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 현재 채팅 동작 방식은 친구를 맺었을 때 자동으로 채팅방이 생성되나, 오간 메시지가 없는 경우 채팅 목록에는 뜨지 않음
- 친구에게 최초로 채팅 메시지를 보내려 할 때, 채팅 목록에는 해당 채팅방이 존재하지 않기 때문에 친구 목록에서 채팅 아이콘을 눌러 메시지를 전송해야 하는데, 이 때 채팅방 ID를 알아야 함.
- 따라서 친구 ID를 보내면 친구와의 1:1 채팅방 ID를 반환하는 API를 추가함 
- (기존 API는 친구와의 모든 채팅방 리스트를 반환하는데, 엄밀히 따지면 이는 다대다 채팅방도 포함하기 때문에 따로 API를 추가함)
- 추가된 API
  - `chat/rooms/one_on_one/<int:pk>/` ([postman](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-8eec02f6-a6ba-4f57-95b5-4fde4ec59973))
    - response 예시: `{"chat_room_id": 4}`
## Preview Image

## Further comments
