### PR TITLE
(#182) chat room info api

### DIFF
--- a/adoorback/chat/urls.py
+++ b/adoorback/chat/urls.py
@@ -6,7 +6,8 @@ from . import views
 
 urlpatterns = [
     path('rooms/', views.ChatRoomList.as_view()),
-    path('rooms/<int:pk>/', views.ChatRoomFriendList.as_view()),
+    path('rooms/<int:pk>/', views.ChatRoomDetail.as_view()),
+    path('rooms/friend/<int:pk>/', views.ChatRoomFriendList.as_view()),
     path('<int:pk>/messages/', views.ChatMessagesListView.as_view()),
     path('rooms/one_on_one/<int:pk>/', views.OneOnOneChatRoomId.as_view()),
 ]

--- a/adoorback/chat/views.py
+++ b/adoorback/chat/views.py
@@ -3,11 +3,12 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response
 
+from adoorback.utils.validators import adoor_exception_handler
 from chat.models import Message, ChatRoom
+import chat.serializers as cs
 from collections import OrderedDict
 from account.models import User
 
-import chat.serializers as cs
 
 class ChatRoomList(generics.ListAPIView):
     """
@@ -32,6 +33,28 @@ class ReversePagination(PageNumberPagination):
             ('previous', self.get_previous_link()),
             ('results', list(reversed(data)))
         ]))
+
+
+class ChatRoomDetail(generics.RetrieveAPIView):
+    serializer_class = cs.ChatRoomSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def get_object(self):
+        chat_room_id = self.kwargs.get('pk')
+        current_user = self.request.user
+
+        try:
+            chat_room = ChatRoom.objects.get(id=chat_room_id)
+        except ChatRoom.DoesNotExist:
+            raise exceptions.NotFound("ChatRoom not found")
+
+        if current_user not in chat_room.users.all():
+            raise exceptions.PermissionDenied("You are not a member of this chat room")
+
+        return chat_room
 
 
 class ChatRoomFriendList(generics.ListAPIView):


### PR DESCRIPTION
## Issue Number: #182

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- room ID를 이용해 chatroom의 정보를 반환하는 API
- 기존 API 경로 수정 ([postman](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-030186bd-9c89-4f35-9b46-a48dbcc2979d))
  - `chat/rooms/<int:friendId>/` -> `chat/rooms/friend/<int:friendId>/` (해당 친구와의 모든 채팅방 반환)
- 새 API 생성 ([postman](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-c12f3b65-77ae-457a-a18e-7ffe0d053110))
  - `chat/rooms/<int:roomId>/` (해당 ID의 채팅방 반환)
## Preview Image

## Further comments
