### PR TITLE
(#205) 임시로 jwt 토큰 httponly를 비활성화

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -82,7 +82,8 @@ class UserLogin(APIView):
                 value=access_token,
                 max_age=settings.SIMPLE_JWT['AUTH_COOKIE_MAX_AGE'],
                 secure=settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
-                httponly=settings.SIMPLE_JWT['AUTH_COOKIE_HTTP_ONLY'],
+                # FIXME: 원활한 테스트를 위해 일단 XSS 보안 이슈는 스킵
+                # httponly=settings.SIMPLE_JWT['AUTH_COOKIE_HTTP_ONLY'],
                 samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE']
             )
             csrf.get_token(request)
@@ -207,7 +208,8 @@ class UserSignup(generics.CreateAPIView):
             value=access_token,
             max_age=settings.SIMPLE_JWT['AUTH_COOKIE_MAX_AGE'],
             secure=settings.SIMPLE_JWT['AUTH_COOKIE_SECURE'],
-            httponly=settings.SIMPLE_JWT['AUTH_COOKIE_HTTP_ONLY'],
+            # FIXME: 원활한 테스트를 위해 일단 보안 이슈는 스킵
+            # httponly=settings.SIMPLE_JWT['AUTH_COOKIE_HTTP_ONLY'],
             samesite=settings.SIMPLE_JWT['AUTH_COOKIE_SAMESITE']
         )
         csrf.get_token(request)


### PR DESCRIPTION
## Issue Number: #205

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
현재, httpOnly 쿠키 형태로 앱 푸시 노티(https://github.com/GooJinSun/WhoAmI-Today-app/issues/59) /채팅 소켓 인증(https://github.com/GooJinSun/WhoAmI-Today-backend/issues/184)%EB%93%B1%EC%9D%98 이슈가 있어, 이 이슈의 명확한 해결책이 생기기 전까지 임시로 jwt 토큰 httponly를 비활성화 합니다

[참고] JWT 인증 관련 이전 이슈 이력
TLDR; 이전 JWT 토큰을 저장하는 방식(not HTTPOnly)은 XSS 보안에 취약할 수 있어 httpOnly Cookie를 활성화 한 상태
https://github.com/GooJinSun/diivers/issues/216
https://github.com/GooJinSun/WhoAmI-Today-backend/issues/1
## Preview Image
### as-is
![스크린샷 2024-04-20 오후 2 56 47](https://github.com/GooJinSun/WhoAmI-Today-backend/assets/37523788/1fe00c3d-5aec-4619-8d16-89d6162aa39a)
### to-be
![스크린샷 2024-04-20 오후 2 56 16](https://github.com/GooJinSun/WhoAmI-Today-backend/assets/37523788/80fb10d1-cf6c-4039-9461-235a1ac8e12b)

## Further comments
