### PR TITLE
(#242) add private comments to comment list api

### DIFF
--- a/adoorback/note/views.py
+++ b/adoorback/note/views.py
@@ -39,7 +39,8 @@ class NoteComments(generics.ListAPIView):
         return adoor_exception_handler
 
     def get_queryset(self):
-        return Note.objects.get(id=self.kwargs.get('pk')).note_comments.all()
+        current_user = self.request.user
+        return Note.objects.get(id=self.kwargs.get('pk')).note_comments.exclude(author_id__in=current_user.user_report_blocked_ids)
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())

--- a/adoorback/qna/views.py
+++ b/adoorback/qna/views.py
@@ -93,7 +93,8 @@ class ResponseComments(generics.ListAPIView):
         return adoor_exception_handler
 
     def get_queryset(self):
-        return Response.objects.get(id=self.kwargs.get('pk')).response_comments.all()
+        current_user = self.request.user
+        return Response.objects.get(id=self.kwargs.get('pk')).response_comments.exclude(author_id__in=current_user.user_report_blocked_ids)
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())


### PR DESCRIPTION
## Issue Number: #242

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 댓글 GET API에서 비밀댓글, 비밀 대댓글의 경우, 다른 필드를 모두 삭제하고 `{"is_private": true}` 형태로 리스트에 포함하여 반환
- 단, 본인이 작성한 비밀댓글/대댓글의 경우 정상적으로 아래와 같이 리턴됨 (is_private=true를 포함하여 코멘트의 모든 필드 함께 리턴) 
```json
        {
            "id": 208,
            "type": "Comment",
            "content": "asdf",
            "comment_count": 0,
            "like_count": 0,
            "current_user_like_id": null,
            "created_at": "2024-06-07T22:47:15.444450-07:00",
            "is_reply": false,
            "is_private": true,
            "target_id": 30,
            "user_tags": [],
            "author": "http://localhost:8000/api/user/adoor_2/profile/",
            "author_detail": {
                "id": 3,
                "username": "adoor_2",
                "profile_pic": "#0D84D0",
                "url": "http://localhost:8000/api/user/adoor_2/profile/",
                "profile_image": null
            },
            "replies": []
        }
```
## Preview Image

## Further comments
