### PR TITLE
(#123) chat room search

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -8,6 +8,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
 from django.db import transaction, IntegrityError
 from django.db.models import F, Q, Max, Case, When, Value, IntegerField
+from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseNotAllowed, JsonResponse, Http404
 from django.middleware import csrf
 from django.shortcuts import get_object_or_404
@@ -368,15 +369,15 @@ class CurrentUserFriendSearch(generics.ListAPIView):
         return adoor_exception_handler
 
     def get_queryset(self):
-        query = self.request.GET.get('query')
+        query = self.request.GET.get('query', '').replace(" ", "").lower()
         user = self.request.user
-        friends = user.friends.all()
+        friends = user.friends.annotate(lower_username=Lower('username'))
 
         if query:
-            start_friends = friends.filter(username__startswith=query).order_by('username')
-            contain_friends = friends.filter(username__icontains=query).order_by('username')
+            start_friends = friends.filter(lower_username__startswith=query).order_by('username')
+            contain_friends = friends.filter(lower_username__icontains=query).order_by('username')
 
-            qs = start_friends.union(contain_friends, all=False) # start_friends first *then* contain_friends
+            qs = start_friends.union(contain_friends, all=False)  # start_friends first *then* contain_friends
 
             return qs
 

--- a/adoorback/chat/urls.py
+++ b/adoorback/chat/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('rooms/', views.ChatRoomList.as_view()),
     path('rooms/<int:pk>/', views.ChatRoomDetail.as_view()),
     path('rooms/friend/<int:pk>/', views.ChatRoomFriendList.as_view()),
+    path('rooms/search/', views.ChatMessageSearch.as_view()),
     path('<int:pk>/messages/', views.ChatMessagesListView.as_view()),
     path('rooms/one_on_one/<int:pk>/', views.OneOnOneChatRoomId.as_view()),
     path('messages/likes/<int:pk>', views.MessageLikeList.as_view(), name='message-like-list'),


### PR DESCRIPTION
## Issue Number: #123

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
채팅 목록 검색에는 두 가지 API가 필요한 것으로 이해했습니다.

1. account 검색 API
2. 채팅 메시지 검색 API

1의 경우, 기존에 있던 GET `user/me/search` 와 동일하여, 해당 API에 `chat_room_id` 필드만 추가해주었습니다.
postman: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-d6a5bd2a-cab5-479c-91fc-da995adab77a?action=share&source=copy-link&creator=6673035&ctx=documentation

2의 경우, GET `chat/rooms/search` API를 새롭게 구현하였습니다.
query가 포함된 메시지를 최신순으로 리턴합니다.
postman: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-aac88d99-fa90-4648-b310-2d683f341283?action=share&source=copy-link&creator=6673035&ctx=documentation

## Preview Image

## Further comments
