### PR TITLE
(#302) 프로필 사진이 업데이트되는 경우, 이미 존재하는 프로필 이미지 유지하고 새로운 이미지 명으로 저장하도록 수정

### DIFF
--- a/adoorback/account/models.py
+++ b/adoorback/account/models.py
@@ -50,10 +50,6 @@ ETHNICITY_CHOICES = (
 class OverwriteStorage(FileSystemStorage):
     base_url = urllib.parse.urljoin(settings.BASE_URL, settings.MEDIA_URL)
 
-    # def get_available_name(self, name, max_length=None):
-    #     if self.exists(name):
-    #         os.remove(os.path.join(settings.MEDIA_ROOT, name))
-    #     return name
 
 def to_profile_images(instance, filename):
     return 'profile_images/{username}.png'.format(username=instance)

--- a/adoorback/account/models.py
+++ b/adoorback/account/models.py
@@ -49,11 +49,10 @@ ETHNICITY_CHOICES = (
 class OverwriteStorage(FileSystemStorage):
     base_url = urllib.parse.urljoin(settings.BASE_URL, settings.MEDIA_URL)
 
-    def get_available_name(self, name, max_length=None):
-        if self.exists(name):
-            os.remove(os.path.join(settings.MEDIA_ROOT, name))
-        return name
-
+    # def get_available_name(self, name, max_length=None):
+    #     if self.exists(name):
+    #         os.remove(os.path.join(settings.MEDIA_ROOT, name))
+    #     return name
 
 def to_profile_images(instance, filename):
     return 'profile_images/{username}.png'.format(username=instance)


### PR DESCRIPTION
## Issue Number: #302

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
프로필 사진이 업데이트되는 경우, 이미 존재하는 프로필 이미지 유지하고 새로운 이미지 명으로 저장하도록 수정

## Preview Image
- 프로필 사진이 업데이트 되는 경우, 아래 이미지와 같이 username.{HASH}.png 로 저장됨
> 이 구조로 가게되면, 유저들의 이전 프로필 이미지가 남는 문제가 있을 수 있는데요, 이전 프로필 이미지를 삭제하고 hash만 바꿔서 저장하는 좋은 아이디어가 있다면 환영합니당
<img width="408" alt="스크린샷 2024-08-17 오후 3 12 49" src="https://github.com/user-attachments/assets/8dca0cbe-ec3c-42d7-98f9-b4a53246050b">

## Further comments

