### PR TITLE
(#305) add read all notifications API

### DIFF
--- a/adoorback/notification/urls.py
+++ b/adoorback/notification/urls.py
@@ -8,4 +8,5 @@ urlpatterns = [
     path('response-requests/', views.ResponseRequestNotiList.as_view(), name='response-request-noti-list'),
     path(r'unread/', views.notification_id, name='notification-id'),
     path('read/', views.NotificationDetail.as_view(), name='notification-read'),
+    path('mark-all-read/', views.MarkAllNotificationsRead.as_view(), name='mark-all-notifications-read'),
 ]

--- a/adoorback/notification/views.py
+++ b/adoorback/notification/views.py
@@ -86,3 +86,18 @@ class NotificationDetail(generics.UpdateAPIView):
         serializer = self.get_serializer(queryset, many=True)
 
         return Response(serializer.data)
+
+
+class MarkAllNotificationsRead(generics.GenericAPIView):
+    permission_classes = [IsAuthenticated, IsOwnerOrReadOnly]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    @transaction.atomic
+    def patch(self, request, *args, **kwargs):
+        user = request.user
+        notifications = Notification.objects.unread_only(user=user)
+        notifications.update(is_read=True)
+        
+        return Response(status=200)


### PR DESCRIPTION
## Issue Number: #305

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 노티 전체 읽음 API
- postman: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-9632ed7b-f39e-4d10-bb1e-3e3d942f8d9b?action=share&source=copy-link&creator=6673035
- @koyrkr 전체 읽음 처리 후 다시 노티 데이터 전체를 리턴하는 대신 그냥 프론트에서 색깔만 바꿔주는 게 더 빠르지 않을까 싶어서 리턴하는 데이터는 없는데 혹시 문제가 된다면 알려주세요!

## Preview Image

## Further comments
