### PR TITLE
(#162) set comment API permissions

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -794,6 +794,7 @@ class UserFriendRequestUpdate(generics.UpdateAPIView):
 
 class UserRecommendedFriendsList(generics.ListAPIView):
     serializer_class = UserMinimumSerializer
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         user_id = self.request.user.id

--- a/adoorback/adoorback/utils/permissions.py
+++ b/adoorback/adoorback/utils/permissions.py
@@ -28,7 +28,7 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
 
 class IsShared(permissions.BasePermission):
     """
-    Custom permission to only allow friends of author to view author profile.
+    Custom permission to only allow friends of author to view.
     """
 
     def has_object_permission(self, request, view, obj):

--- a/adoorback/chat/views.py
+++ b/adoorback/chat/views.py
@@ -116,6 +116,7 @@ class ChatMessageSearch(generics.ListAPIView):
 class ChatMessagesListView(generics.ListAPIView):
     serializer_class = cs.ChatRoomMessageSerializer
     pagination_class = ReversePagination
+    permission_classes = [IsAuthenticated]
 
     def get_queryset(self):
         try:

--- a/adoorback/comment/models.py
+++ b/adoorback/comment/models.py
@@ -6,20 +6,20 @@ from django.contrib.auth import get_user_model
 from django.dispatch import receiver
 from django.db.models.signals import post_save
 from django.db import IntegrityError
-
-from like.models import Like
-from account.models import User
-from notification.models import Notification, NotificationActor
-from user_tag.models import UserTag
-from adoorback.models import AdoorModel
-
-from adoorback.utils.helpers import wrap_content
-from adoorback.utils.content_types import get_comment_type, get_generic_relation_type
-from utils.helpers import parse_user_tag_from_content
-
 from safedelete.models import SafeDeleteModel
 from safedelete.models import SOFT_DELETE_CASCADE
 from safedelete.managers import SafeDeleteManager
+
+from account.models import User
+from adoorback.models import AdoorModel
+from adoorback.utils.helpers import wrap_content
+from adoorback.utils.content_types import get_comment_type, get_generic_relation_type
+from content_report.models import ContentReport
+from like.models import Like
+from notification.models import Notification, NotificationActor
+from user_tag.models import UserTag
+from utils.helpers import parse_user_tag_from_content
+
 
 User = get_user_model()
 
@@ -67,6 +67,9 @@ class Comment(AdoorModel, SafeDeleteModel):
     @property
     def participants(self):
         return self.replies.values_list('author_id', flat=True).distinct()
+
+    def is_reply(self):
+        return isinstance(self.target, Comment)
 
 
 @receiver(post_save, sender=Comment)

--- a/adoorback/notification/views.py
+++ b/adoorback/notification/views.py
@@ -16,7 +16,7 @@ from adoorback.utils.content_types import get_friend_request_type, get_response_
 
 class NotificationList(generics.ListAPIView):
     serializer_class = NotificationSerializer
-    permission_classes = [IsAuthenticated, IsOwnerOrReadOnly]
+    permission_classes = [IsAuthenticated]
 
     def get_exception_handler(self):
         return adoor_exception_handler
@@ -34,7 +34,7 @@ class NotificationList(generics.ListAPIView):
 
 class FriendRequestNotiList(generics.ListAPIView):
     serializer_class = NotificationSerializer
-    permission_classes = [IsAuthenticated, IsOwnerOrReadOnly]
+    permission_classes = [IsAuthenticated]
 
     def get_exception_handler(self):
         return adoor_exception_handler
@@ -49,7 +49,7 @@ class FriendRequestNotiList(generics.ListAPIView):
 
 class ResponseRequestNotiList(generics.ListAPIView):
     serializer_class = NotificationSerializer
-    permission_classes = [IsAuthenticated, IsOwnerOrReadOnly]
+    permission_classes = [IsAuthenticated]
 
     def get_exception_handler(self):
         return adoor_exception_handler


### PR DESCRIPTION
## Issue Number: #162

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- response, note의 댓글 조회 관련 API에 권한이 있는 사람만 접근할 수 있도록 제한합니다.
- FYI) `BasePermission`을 상속한 permission class의 `has_object_permission` 함수는 `ListAPIView`에서는 동작하지 않음
  - 참고) https://stackoverflow.com/questions/54783424/has-object-permission-not-called
  - 기존 코드 중 `IsNotBlocked` 등이 `ListAPIView`에 적용되어있는 경우들이 있어서, 이 부분도 추가로 수정하였음
  - `ListAPIView`의 경우 리스트의 각 object에 대한 추가 permission check가 필요한 경우, `permission_classes`로 불가능하기 때문에 `get_queryset()` 등의 메소드 내에서 직접 필터링 로직을 넣어주어야 함

## Preview Image

## Further comments
