### PR TITLE
(#332, #335) fix daily noti bug

### DIFF
--- a/adoorback/account/cron.py
+++ b/adoorback/account/cron.py
@@ -22,9 +22,10 @@ class SendDailyWhoAmINotiCronJob(CronJobBase):
         print('=========================')
         print("Creating daily notifications for WhoAmI...............")
 
-        admin = User.objects.filter(is_superuser=True).first()
+        admin = User.objects.filter(is_superuser=True).get(email='team.whoami.today@gmail.com')
         try:
-            daily_question = Question.objects.daily_questions()[0].content
+            daily_question_en = Question.objects.daily_questions()[0].content_en
+            daily_question_ko = Question.objects.daily_questions()[0].content_ko
         except:
             print('=========================')
             print('daily question does not exist!')
@@ -42,8 +43,8 @@ class SendDailyWhoAmINotiCronJob(CronJobBase):
                 noti = Notification.objects.create(user=user,
                                                    target=admin,
                                                    origin=admin,
-                                                   message_ko=f"{user.username}님, 오늘의 후엠아이를 남겨보세요! - {daily_question}",
-                                                   message_en=f"{user.username}, time to leave your whoami for today! - {daily_question}",
+                                                   message_ko=f"{user.username}님, 오늘의 후엠아이를 남겨보세요! - {daily_question_ko}",
+                                                   message_en=f"{user.username}, time to leave your whoami for today! - {daily_question_en}",
                                                    redirect_url='/')
                 NotificationActor.objects.create(user=admin, notification=noti)
 

--- a/adoorback/account/models.py
+++ b/adoorback/account/models.py
@@ -128,6 +128,9 @@ class User(AbstractUser, AdoorTimestampedModel, SafeDeleteModel):
         ]
         ordering = ['id']
 
+    def __str__(self):
+        return self.username
+
     def save(self, *args, **kwargs):
         # Ensure that only friends can be added to favorites or hidden
         if self.id is not None:  # Existing user

--- a/adoorback/qna/models.py
+++ b/adoorback/qna/models.py
@@ -36,9 +36,7 @@ class QuestionManager(SafeDeleteManager):
 
     def daily_questions(self, **kwargs):
         today = timezone.now().date()
-        six_days_ago = today - datetime.timedelta(days=6)
-        date_list = [six_days_ago + datetime.timedelta(days=x) for x in range(0, (today - six_days_ago).days + 1)]
-        return self.filter(selected_dates__overlap=date_list, **kwargs)
+        return self.filter(selected_dates__contains=[today], **kwargs)
 
     def date_questions(self, date, **kwargs):
         return self.filter(selected_dates__contains=[date], **kwargs)


### PR DESCRIPTION
## Issue Number: #332, #335

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 데일리 노티 내용이 계속 같은 버그 수정
  - `daily_questions()` 함수가 최근 6일 질문을 모두 가져오게 구현되어있어 발생하던 문제
    - `daily_questions()` 함수는 오늘의 질문만 반환하도록 수정
  - 추가로, 해당 함수를 사용하고 있던 DailyQuesionList API (`/qna/questions/daily/`)는 '오늘의 질문' 섹션에서만 호출되도록 프론트 수정 필요
    - '새 답변 작성 > 최근 질문'과 질문 탭에서는 QuestionList API (`/qna/questions/`)를 호출해야 함
    - 두 API에서 맨 앞 오늘의 질문의 순서가 일치하도록 로직 수정함
- 데일리 노티에서 질문 내용 언어 설정 추가
- 데일리 노티 보내는 actor이 adoor 슈퍼유저가 아닌 whoamitoday 슈퍼유저가 되도록 수정

cc. @GooJinSun @koyrkr 

## Preview Image

## Further comments
