### PR TITLE
(#369) add current_user_reaction_id_list to post serializers

### DIFF
--- a/adoorback/note/serializers.py
+++ b/adoorback/note/serializers.py
@@ -3,8 +3,8 @@ from rest_framework import serializers
 from account.serializers import UserMinimalSerializer
 from adoorback.serializers import AdoorBaseSerializer
 from adoorback.utils.content_types import get_generic_relation_type
-from like.models import Like
 from note.models import Note
+from reaction.models import Reaction
 
 
 class NoteSerializer(AdoorBaseSerializer):
@@ -12,15 +12,9 @@ class NoteSerializer(AdoorBaseSerializer):
         view_name='user-detail', read_only=True, lookup_field='author', lookup_url_kwarg='username')
     author_detail = UserMinimalSerializer(source='author', read_only=True)
     images = serializers.SerializerMethodField()
-    current_user_like_id = serializers.SerializerMethodField(read_only=True)
     current_user_read = serializers.SerializerMethodField(read_only=True)
     like_user_sample = serializers.SerializerMethodField(read_only=True)
-
-    def get_current_user_like_id(self, obj):
-        current_user_id = self.context['request'].user.id
-        content_type_id = get_generic_relation_type(obj.type).id
-        like = Like.objects.filter(user_id=current_user_id, content_type_id=content_type_id, object_id=obj.id)
-        return like[0].id if like else None
+    current_user_reaction_id_list = serializers.SerializerMethodField(read_only=True)
 
     def get_current_user_read(self, obj):
         current_user_id = self.context['request'].user.id
@@ -35,9 +29,15 @@ class NoteSerializer(AdoorBaseSerializer):
         recent_likes = obj.note_likes.order_by('-created_at')[:3]
         recent_users = [like.user for like in recent_likes]
         return UserMinimalSerializer(recent_users, many=True, context=self.context).data
+    
+    def get_current_user_reaction_id_list(self, obj):
+        current_user_id = self.context['request'].user.id
+        content_type_id = get_generic_relation_type(obj.type).id
+        reactions = Reaction.objects.filter(user_id=current_user_id, content_type_id=content_type_id, object_id=obj.id)
+        return [{"id": reaction.id, "emoji": reaction.emoji} for reaction in reactions]
 
     class Meta(AdoorBaseSerializer.Meta):
         model = Note
         fields = AdoorBaseSerializer.Meta.fields + ['author', 'author_detail', 'images', 'current_user_like_id', 
-                                                    'current_user_read', 'like_user_sample', 'is_edited']
+                                                    'current_user_read', 'like_user_sample', 'current_user_reaction_id_list', 'is_edited']
 

--- a/adoorback/user_report/serializers.py
+++ b/adoorback/user_report/serializers.py
@@ -2,7 +2,6 @@ from rest_framework import serializers
 from django.contrib.auth import get_user_model
 
 from user_report.models import UserReport
-from adoorback.serializers import AdoorBaseSerializer
 
 User = get_user_model()
 


### PR DESCRIPTION
## Issue Number: #369

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- note, response 객체를 반환할 때 `current_user_reaction_id_list`가 추가되었습니다
```
            "current_user_reaction_id_list": [
                {
                    "id": 3,
                    "emoji": "😇"
                },
                {
                    "id": 4,
                    "emoji": "😅"
                }
            ],
```
## Preview Image

## Further comments
