### PR TITLE
(#368) retrieve like + reaction sample users for post

### DIFF
--- a/adoorback/note/models.py
+++ b/adoorback/note/models.py
@@ -19,6 +19,7 @@ from comment.models import Comment
 from content_report.models import ContentReport
 from like.models import Like
 from notification.models import Notification, NotificationActor
+from reaction.models import Reaction
 
 User = get_user_model()
 
@@ -79,6 +80,12 @@ class Note(AdoorModel, SafeDeleteModel):
     @property
     def reader_ids(self):
         return self.readers.values_list('id', flat=True)
+
+    @property
+    def reactions(self):
+        from django.contrib.contenttypes.models import ContentType
+        note_content_type = ContentType.objects.get_for_model(self)
+        return Reaction.objects.filter(content_type=note_content_type, object_id=self.id)
 
     def is_audience(self, user):
         content_type = ContentType.objects.get_for_model(self)

--- a/adoorback/note/serializers.py
+++ b/adoorback/note/serializers.py
@@ -1,3 +1,7 @@
+from itertools import chain
+
+from django.contrib.auth import get_user_model
+from django.db.models import F, Value, CharField, BooleanField
 from rest_framework import serializers
 
 from account.serializers import UserMinimalSerializer
@@ -7,14 +11,17 @@ from note.models import Note
 from reaction.models import Reaction
 
 
+User = get_user_model()
+
+
 class NoteSerializer(AdoorBaseSerializer):
     author = serializers.HyperlinkedIdentityField(
         view_name='user-detail', read_only=True, lookup_field='author', lookup_url_kwarg='username')
     author_detail = UserMinimalSerializer(source='author', read_only=True)
     images = serializers.SerializerMethodField()
     current_user_read = serializers.SerializerMethodField(read_only=True)
-    like_user_sample = serializers.SerializerMethodField(read_only=True)
     current_user_reaction_id_list = serializers.SerializerMethodField(read_only=True)
+    like_reaction_user_sample = serializers.SerializerMethodField(read_only=True)
 
     def get_current_user_read(self, obj):
         current_user_id = self.context['request'].user.id
@@ -23,12 +30,6 @@ class NoteSerializer(AdoorBaseSerializer):
     def get_images(self, obj):
         images = obj.images.all().order_by('created_at')
         return [image.image.url for image in images]
-
-    def get_like_user_sample(self, obj):
-        from account.serializers import UserMinimalSerializer
-        recent_likes = obj.note_likes.order_by('-created_at')[:3]
-        recent_users = [like.user for like in recent_likes]
-        return UserMinimalSerializer(recent_users, many=True, context=self.context).data
     
     def get_current_user_reaction_id_list(self, obj):
         current_user_id = self.context['request'].user.id
@@ -36,8 +37,38 @@ class NoteSerializer(AdoorBaseSerializer):
         reactions = Reaction.objects.filter(user_id=current_user_id, content_type_id=content_type_id, object_id=obj.id)
         return [{"id": reaction.id, "emoji": reaction.emoji} for reaction in reactions]
 
+    def get_like_reaction_user_sample(self, obj):
+        from account.serializers import UserMinimalSerializer
+
+        likes = obj.note_likes.annotate(
+            created=F('created_at'),
+            like=Value(True, output_field=BooleanField()),
+            reaction=Value(None, output_field=CharField())
+        ).values('user', 'created', 'like', 'reaction')
+
+        reactions = obj.reactions.annotate(
+            created=F('created_at'),
+            like=Value(False, output_field=BooleanField()),
+            reaction=F('emoji')
+        ).values('user', 'created', 'like', 'reaction')
+
+        combined = sorted(
+            chain(likes, reactions),
+            key=lambda x: x['created'],
+            reverse=True
+        )[:3]
+
+        serialized_data = []
+        for reaction in combined:
+            user = User.objects.get(id=reaction['user'])
+            user_data = UserMinimalSerializer(user, context=self.context).data
+            user_data['like'] = reaction['like']
+            user_data['reaction'] = reaction['reaction']
+            serialized_data.append(user_data)
+
+        return serialized_data
+
     class Meta(AdoorBaseSerializer.Meta):
         model = Note
         fields = AdoorBaseSerializer.Meta.fields + ['author', 'author_detail', 'images', 'current_user_like_id', 
-                                                    'current_user_read', 'like_user_sample', 'current_user_reaction_id_list', 'is_edited']
-
+                                                    'current_user_read', 'like_reaction_user_sample', 'current_user_reaction_id_list', 'is_edited']

--- a/adoorback/qna/models.py
+++ b/adoorback/qna/models.py
@@ -123,6 +123,12 @@ class Response(AdoorModel, SafeDeleteModel):
     def reader_ids(self):
         return self.readers.values_list('id', flat=True)
 
+    @property
+    def reactions(self):
+        from django.contrib.contenttypes.models import ContentType
+        response_content_type = ContentType.objects.get_for_model(self)
+        return Reaction.objects.filter(content_type=response_content_type, object_id=self.id)
+
     def is_audience(self, user):
         content_type = ContentType.objects.get_for_model(self)
         if ContentReport.objects.filter(user=user, content_type=content_type, object_id=self.pk).exists():


### PR DESCRIPTION
## Issue Number: #368

## Self Check List

- [x] !!! PR이 머지되는 base branch을 꼭 확인해주세요 !!!
- [x] base branch로부터 rebase를 했나요?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- add `like_reaction_user_sample` field to Note & Response serializers
  - this field contains 3 recent reactors including like & emoji reactions

## Preview Image

## Further comments
