### PR TITLE
(#363) change email host for password reset

### DIFF
--- a/adoorback/adoorback/settings/base.py
+++ b/adoorback/adoorback/settings/base.py
@@ -223,9 +223,9 @@ EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
 EMAIL_USE_TLS = True
 EMAIL_PORT = 587
 EMAIL_HOST = 'smtp.gmail.com' 
-EMAIL_HOST_USER = 'adoor.team@gmail.com'
+EMAIL_HOST_USER = 'whoami.today.official@gmail.com'
 EMAIL_HOST_PASSWORD = os.environ['EMAIL_HOST_PASSWORD']
-SERVER_EMAIL = 'adoor.team'
+SERVER_EMAIL = 'whoami.today.official@gmail.com'
 
 # https://fcm-django.readthedocs.io/en/latest/
 FIREBASE_CREDENTIAL_PATH = os.path.join(BASE_DIR, 'serviceAccountKey.json')


### PR DESCRIPTION
## Issue Number: #363

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
Due to the change in the Google account, the host account settings for sending emails in Django have been updated. Accordingly, the environment variables stored in local .zshrc, .bashrc, .bash_profile must be updated, as well as the server's `adoorback/.config/uwsgi/env` file.

changed `EMAIL_HOST_PASSWORD` value: https://www.notion.so/jinsungoo/EN-WIT-Onboarding-Guide-335b2f0cecfb46d58fefe59e62d890e9?pvs=4#151056a5969a4977a93cd63ca5b6aee3
## Preview Image

## Further comments
