### PR TITLE
remove backport requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@
 
 # python
 adoorback/.python-version
+
+# Google translation
+/adoorback/coherent-flame-438905-n8-31fc61ebb01c.json

--- a/adoorback/adoorback/utils/authentication.py
+++ b/adoorback/adoorback/utils/authentication.py
@@ -3,7 +3,7 @@ from rest_framework import authentication
 from rest_framework import exceptions
 from rest_framework.authentication import CSRFCheck
 from rest_framework_simplejwt.authentication import JWTAuthentication
-from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 from django.utils import timezone
 
 

--- a/adoorback/requirements.txt
+++ b/adoorback/requirements.txt
@@ -4,7 +4,6 @@ asgiref>=3.2.10
 astroid>=2.4.2
 autopep8>=1.5.4
 awesome-slugify>=1.6.5
-backports.zoneinfo==0.2.1
 beautifulsoup4>=4.6.0
 billiard>=3.6.3.0
 binaryornot>=0.4.4


### PR DESCRIPTION
## Issue Number:

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
removing backport requirement, and changing the `authentication.py` code accordingly, given
1. it doesn't install properly on my laptop
2. [this reference](https://stackoverflow.com/questions/71712258/error-could-not-build-wheels-for-backports-zoneinfo-which-is-required-to-insta) that it shouldn't be used for Python >= 3.9

## Preview Image

## Further comments
