### PR TITLE
(#389) Ping API modifications

### DIFF
--- a/adoorback/ping/serializers.py
+++ b/adoorback/ping/serializers.py
@@ -12,5 +12,5 @@ class PingSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Ping
-        fields = ['id', 'sender', 'emoji', 'content']
+        fields = ['id', 'sender', 'emoji', 'content', 'is_read']
 

--- a/adoorback/ping/urls.py
+++ b/adoorback/ping/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('user/<int:pk>/', views.PingList.as_view(), name='ping_list'),
+    path('<int:pk>/mark-as-read/', views.MarkPingAsRead.as_view(), name='mark-ping-as-read'),
 ]

--- a/adoorback/ping/views.py
+++ b/adoorback/ping/views.py
@@ -1,9 +1,11 @@
 from django.contrib.auth import get_user_model
-from django.shortcuts import render
-from rest_framework import generics, exceptions
+from django.shortcuts import get_object_or_404
+from rest_framework import generics, exceptions, status
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from .models import Ping, get_or_create_ping_room, mark_pings_as_read
+from .models import Ping, get_or_create_ping_room
 from .serializers import PingSerializer
 
 User = get_user_model()
@@ -18,15 +20,11 @@ class PingList(generics.ListCreateAPIView):
         try:
             connected_user = User.objects.get(id=self.kwargs.get('pk'))
             if not user.is_connected(connected_user):
-                print('??')
                 raise exceptions.PermissionDenied("You are not connected to this user")
         except User.DoesNotExist:
             raise exceptions.NotFound("Connected user not found")
 
         ping_room = get_or_create_ping_room(connected_user, user)
-
-        # mark pings in ping_room as read
-        mark_pings_as_read(user, ping_room)
 
         pings = Ping.objects.filter(ping_room=ping_room)
         return pings
@@ -45,3 +43,17 @@ class PingList(generics.ListCreateAPIView):
 
         serializer.save(sender=user, receiver=connected_user, ping_room=ping_room)
 
+
+class MarkPingAsRead(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request, pk):
+        user = request.user
+        ping = get_object_or_404(Ping, id=pk, receiver=user)
+
+        if ping.is_read:
+            return Response({"detail": "Ping is already marked as read."}, status=status.HTTP_400_BAD_REQUEST)
+        
+        ping.is_read = True
+        ping.save()
+        return Response({"detail": "Ping marked as read."}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Issue Number: #389

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- When returning ping list, `'is_read'` field is returned as well
  - Pings with `is_read=False` must be shown as folded(?) and waiting in a queue, and must open only when user clicks on the it.
  - When user clicks on the waiting ping and the ping content is revealed to the user, mark ping as read API must be called
  - mark ping as read API: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-eab70bc7-4685-48c0-b58f-8375fb7a616f?action=share&creator=6673035&ctx=documentation
- `has_unread_pings` (boolean) field has been changed to `unread_ping_count` in 2 friend related APIs
  - `user/friends/`
  - `user/<str:username>/profile/`
## Preview Image

## Further comments
