### PR TITLE
(#426) like related APIs for default ver.

### DIFF
--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path(r'search/', views.UserSearch.as_view(), name='user-search'),
     path('<str:username>/profile/', views.UserProfile.as_view(), name='user-detail'),
     path('<str:username>/notes/', views.UserNoteList.as_view(), name='user-note-list'),
+    path('<str:username>/notes/default/', views.DefaultUserNoteList.as_view(), name='default-user-note-list'),
     path('<str:username>/responses/', views.UserResponseList.as_view(), name='user-response-list'),
     path('mark-all-notes-as-read/', views.UserMarkAllNotesAsRead.as_view(), name='user-mark-all-as-read'),
     path('mark-all-responses-as-read/', views.UserMarkAllResponsesAsRead.as_view(), name='user-mark-all-as-read'),

--- a/adoorback/note/urls.py
+++ b/adoorback/note/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('', views.NoteCreate.as_view(), name='note-list'),
     path('<int:pk>/', views.NoteDetail.as_view(), name='note-detail'),
     path('<int:pk>/comments/', views.NoteComments.as_view(), name='note-comments'),
+    path('<int:pk>/likes/', views.NoteLikes.as_view(), name='note-likes'),  # for default ver.
     path('<int:pk>/interactions/', views.NoteInteractions.as_view(), name='note-interaction-user-list'),
     path('read/', views.NoteRead.as_view(), name='note-read'),
 ]

--- a/adoorback/note/views.py
+++ b/adoorback/note/views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 from adoorback.utils.permissions import IsNotBlocked, IsAuthorOrReadOnly, IsShared
 from adoorback.utils.validators import adoor_exception_handler
 import comment.serializers as cs
-from like.serializers import InteractionSerializer
+from like.serializers import InteractionSerializer, LikeSerializer
 from note.models import Note, NoteImage
 from note.serializers import NoteSerializer
 
@@ -120,6 +120,20 @@ class NoteDetail(generics.RetrieveUpdateDestroyAPIView):
         
         self.perform_update(serializer)
         return Response(serializer.data)
+
+
+class NoteLikes(generics.ListAPIView):
+    '''
+    for default ver., visible to friends
+    '''
+    serializer_class = LikeSerializer
+    permission_classes = [IsAuthenticated, IsAuthorOrReadOnly]
+
+    def get_queryset(self):
+        from like.models import Like
+        note_id = self.kwargs['pk']
+
+        return Like.objects.filter(content_type__model='note', object_id=note_id)
 
 
 class NoteInteractions(generics.ListAPIView):


### PR DESCRIPTION
## Issue Number: #426

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
디폴트 버전을 위한 like 관련 API 추가
  1) 친구의 note list API
    - GET `api/user/<str:username>/notes/default/`
    - postman: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-ae5c9f9e-d770-4675-8ce7-b9a6ea01922a?action=share&creator=6673035&ctx=documentation
    - 기존 `api/user/<str:username>/notes/`와 아래와 같은 차이점이 있음 
      - `like_count` 필드가 null로 오지 않음
      - `like_reaction_user_sample` 필드 대신 `like_user_sample`
      - `current_user_reaction_id` 필드 삭제
  2) 나 혹은 친구의 note like list API
    - GET `api/notes/<int:pk>/likes/`
    - postman: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-f7b0a7c4-ca48-4028-b46c-a8bc765bde83?action=share&creator=6673035&ctx=documentation
    - 기존 `api/notes/<int:pk>/interactions/`와 아래와 같은 차이점이 있음
      - reaction 빼고 like만 반환
      - note의 author여야만 permission을 갖는 제한을 없앰

## Preview Image

## Further comments
