### PR TITLE
(#427) Ping API update

### DIFF
--- a/adoorback/ping/models.py
+++ b/adoorback/ping/models.py
@@ -89,7 +89,7 @@ class Ping(AdoorTimestampedModel, SafeDeleteModel):
         ordering = ['-created_at']
 
     def __str__(self):
-        return f"{self.sender} sent a {self.get_content_display()} ping to {self.receiver}"
+        return f"{self.sender} sent a {self.content} ping to {self.receiver}"
     
     @property
     def type(self):

--- a/adoorback/ping/serializers.py
+++ b/adoorback/ping/serializers.py
@@ -12,5 +12,5 @@ class PingSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Ping
-        fields = ['id', 'sender', 'emoji', 'content', 'is_read']
+        fields = ['id', 'sender', 'emoji', 'content', 'is_read', 'created_at']
 

--- a/adoorback/ping/urls.py
+++ b/adoorback/ping/urls.py
@@ -4,5 +4,4 @@ from . import views
 
 urlpatterns = [
     path('user/<int:pk>/', views.PingList.as_view(), name='ping_list'),
-    path('<int:pk>/mark-as-read/', views.MarkPingAsRead.as_view(), name='mark-ping-as-read'),
 ]

--- a/adoorback/ping/views.py
+++ b/adoorback/ping/views.py
@@ -75,17 +75,3 @@ class PingList(generics.ListCreateAPIView):
 
         response.data['unread_count'] = unread_count
         return response
-
-# class MarkPingAsRead(APIView):
-#     permission_classes = [IsAuthenticated]
-
-#     def post(self, request, pk):
-#         user = request.user
-#         ping = get_object_or_404(Ping, id=pk, receiver=user)
-
-#         if ping.is_read:
-#             return Response({"detail": "Ping is already marked as read."}, status=status.HTTP_400_BAD_REQUEST)
-        
-#         ping.is_read = True
-#         ping.save()
-#         return Response({"detail": "Ping marked as read."}, status=status.HTTP_200_OK)

--- a/adoorback/ping/views.py
+++ b/adoorback/ping/views.py
@@ -1,9 +1,7 @@
+from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.shortcuts import get_object_or_404
-from rest_framework import generics, exceptions, status
+from rest_framework import generics, exceptions
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from .models import Ping, get_or_create_ping_room
 from .serializers import PingSerializer
@@ -26,8 +24,28 @@ class PingList(generics.ListCreateAPIView):
 
         ping_room = get_or_create_ping_room(connected_user, user)
 
-        pings = Ping.objects.filter(ping_room=ping_room)
+        pings = list(ping_room.pings)  # to freeze the unread status
+
+        oldest_unread = ping_room.pings.filter(receiver=user, is_read=False).order_by('id').first()
+        
+        if oldest_unread:
+            oldest_position = Ping.objects.filter(ping_room=ping_room, id__gte=oldest_unread.id).count()
+            pagination_size = getattr(settings, 'REST_FRAMEWORK', {}).get('PAGE_SIZE', 10)
+            page_number = (oldest_position - 1) // pagination_size + 1
+        else:
+            page_number = 1
+        self.oldest_unread_page = page_number
+
+        # mark all pings as read
+        unread_pings = ping_room.pings.filter(receiver=user, is_read=False)
+        unread_pings.update(is_read=True)
+
         return pings
+    
+    def list(self, request, *args, **kwargs):
+        response = super().list(request, *args, **kwargs)
+        response.data['oldest_unread_page'] = self.oldest_unread_page
+        return response
 
     def perform_create(self, serializer):
         user = self.request.user
@@ -43,17 +61,31 @@ class PingList(generics.ListCreateAPIView):
 
         serializer.save(sender=user, receiver=connected_user, ping_room=ping_room)
 
+    def create(self, request, *args, **kwargs):
+        response = super().create(request, *args, **kwargs)
 
-class MarkPingAsRead(APIView):
-    permission_classes = [IsAuthenticated]
-
-    def post(self, request, pk):
         user = request.user
-        ping = get_object_or_404(Ping, id=pk, receiver=user)
+        try:
+            connected_user = User.objects.get(id=self.kwargs.get('pk'))
+            ping_room = get_or_create_ping_room(user, connected_user)
 
-        if ping.is_read:
-            return Response({"detail": "Ping is already marked as read."}, status=status.HTTP_400_BAD_REQUEST)
+            unread_count = ping_room.pings.filter(receiver=user, is_read=False).count()
+        except User.DoesNotExist:
+            raise exceptions.NotFound("Connected user not found")
+
+        response.data['unread_count'] = unread_count
+        return response
+
+# class MarkPingAsRead(APIView):
+#     permission_classes = [IsAuthenticated]
+
+#     def post(self, request, pk):
+#         user = request.user
+#         ping = get_object_or_404(Ping, id=pk, receiver=user)
+
+#         if ping.is_read:
+#             return Response({"detail": "Ping is already marked as read."}, status=status.HTTP_400_BAD_REQUEST)
         
-        ping.is_read = True
-        ping.save()
-        return Response({"detail": "Ping marked as read."}, status=status.HTTP_200_OK)
+#         ping.is_read = True
+#         ping.save()
+#         return Response({"detail": "Ping marked as read."}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Issue Number: #427

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
기존 ping API에 필요한 필드 업데이트
- mark ping as read는 프론트에서 따로 부를 필요 없음 (API 제거)
    - 새로고침시에나 진입시에 모두 자동으로 read 처리됨.
    - 단, 새로고침시에나 진입시에 리턴되는 ping들 중 새로운 ping들에 `is_read=False`로 표시되어있음 (read 처리되기 이전 상태).
- ping list 호출시 pagination 정보 같이 줌 (oldest_unread_page 필드)
  - ex) oldest_unread_page = 4인 경우, 4번째 페이지까지 로드하면 됨
  - postman: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-26a87881-2e75-4c35-a075-c3d5ad9c66c3?action=share&creator=6673035&ctx=documentation
  - 새로고침할 때도 같은 API 콜하면 됨 (똑같이 pagination 정보 주지만, 사용 안하면 됨)
- ping POST 호출시 `unread_count` 함께 반환 (새로고침 아이콘에 표시)


## Preview Image

## Further comments
