### PR TITLE
(#446) friend request/respond API for default ver.

### DIFF
--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -53,12 +53,16 @@ urlpatterns = [
     # FriendRequest related
     path('friend-requests/', views.UserFriendRequest.as_view(),
          name='user-friend-request-list'),
+    path('friend-requests/default/', views.UserFriendRequestDefault.as_view(), 
+         name='user-friend-request-default'),
     path('friend-requests/sent/', views.UserSentFriendRequestList.as_view(),
          name='user-sent-friend-request-list'),
     path('friend-requests/<int:pk>/', views.UserFriendRequestDestroy.as_view(),
          name='user-friend-request-destroy'),
     path('friend-requests/<int:pk>/respond/', views.UserFriendRequestUpdate.as_view(),
          name='user-friend-request-update'),
+    path('friend-requests/<int:pk>/respond/default/', views.UserFriendRequestUpdateDefault.as_view(), 
+         name='user-friend-request-update-default'),
 
     # Friend Recommend related
     path('recommended-friends/', views.UserRecommendedFriendsList.as_view(), name='user-recommended-friends-list'),


### PR DESCRIPTION
## Issue Number: #446

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
Implementation of friend request/acceptance API for the default version app (final spec [reference link](https://www.notion.so/jaewon-kim/Connection-161f7ff219e581fd944ac0f746877ef5?pvs=4#0ed36838b2484d2f9c1d83f65fa70249))
- POST `api/user/friend-requests/default/`
  - Same as `api/user/friend-requests/` but does not accept `requester_choice` as a parameter.
  - postman: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-5948bd37-2887-4b72-a7f3-c42e01175ce1?action=share&creator=6673035&ctx=documentation
- PATCH `api/user/friend-requests/<int:pk>/respond/default/`
  - Same as `api/user/friend-requests/<int:pk>/respond/` but does not accept `requestee_choice` as a parameter.
  - postman: https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-e41cf6a8-6971-46e2-9e83-8015bf2d94b9?action=share&creator=6673035&ctx=documentation

## Preview Image

## Further comments
