### PR TITLE
[#397] Reset Password Security Enhancement

### DIFF
--- a/adoorback/account/email.py
+++ b/adoorback/account/email.py
@@ -5,6 +5,8 @@ from django.core.mail import EmailMessage
 from django.utils.translation import gettext_lazy as _
 from django.utils.http import urlsafe_base64_encode
 from django.utils.encoding import force_bytes
+from django.utils.timezone import now
+from datetime import timedelta
 
 
 class EmailManager():

--- a/adoorback/account/email.py
+++ b/adoorback/account/email.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from django.contrib.auth.tokens import PasswordResetTokenGenerator
 from django.core.mail import EmailMessage
 from django.utils.translation import gettext_lazy as _
+from django.utils.http import urlsafe_base64_encode
+from django.utils.encoding import force_bytes
 
 
 class EmailManager():
@@ -10,11 +12,14 @@ class EmailManager():
 
     def send_reset_password_email(self, user):
         token = self.pw_reset_token_generator.make_token(user)
+        
+        uid = urlsafe_base64_encode(force_bytes(user.pk))
+        
         mail_title = _("비밀번호 변경 링크입니다.")
         mail_to = [user.email]
         message_data = f"{user.username}"
         message_data += _("님, 아래 링크를 클릭하면 비밀번호 변경이 가능합니다.\n\n비밀번호 변경 링크 : ")
-        message_data += f"{settings.FRONTEND_URL}/reset-password/{user.id}/{token}\n\n"
+        message_data += f"{settings.FRONTEND_URL}/reset-password/{uid}/{token}\n\n"
         message_data += _("감사합니다.")
         email = EmailMessage(mail_title, message_data, to=mail_to)
         email.send()

--- a/adoorback/adoorback/settings/base.py
+++ b/adoorback/adoorback/settings/base.py
@@ -193,9 +193,8 @@ AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator', },
 ]
 
-# Password reset token timeout (3 days in seconds)
-# 60 * 5 for 5 minutes to test
-PASSWORD_RESET_TIMEOUT = 60 * 60 * 24 * 3
+# Password reset token timeout (1 hour in seconds)
+PASSWORD_RESET_TIMEOUT = 60 * 60 
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/

--- a/adoorback/adoorback/settings/base.py
+++ b/adoorback/adoorback/settings/base.py
@@ -193,6 +193,10 @@ AUTH_PASSWORD_VALIDATORS = [
     {'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator', },
 ]
 
+# Password reset token timeout (3 days in seconds)
+# 60 * 5 for 5 minutes to test
+PASSWORD_RESET_TIMEOUT = 60 * 60 * 24 * 3
+
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/
 


### PR DESCRIPTION
## Issue Number:

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
[https://github.com/ssm0318/WhoamI-Today-backend/issues/397](https://github.com/ssm0318/WhoamI-Today-backend/issues/397)
- Removes user ID from email link sent out for security and encodes it via Django's `urlsafe_base64_encode` to replace the raw user ID. Verified that the token's expiration time was implemented in `PasswordResetTokenGenerator`, and ensures that reset password token expires after a set time (currently 3 days in `PASSWORD_RESET_TIMEOUT` in `adoorback/adoorback/settings/base.py`)

### Testing
- First, in the backend, go to `adoorback/adoorback/settings/base.py ` and change `PASSWORD_RESET_TIMEOUT` to `60 * 5` for 5 minutes.
- Next, sign up with a testing account and an email you can access (in this case, I used my own):
  - [POST api/user/signup](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-febc8186-d163-4729-88b1-59aa5526b016)
- Get your user ID and then send the password reset email via Postman:
  - [POST api/user/send-reset-password-email/](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-d77530d1-3152-4f8c-b7a2-50206acdbb0f)
- Go to your email and find the reset password email. Copy the token in the URL and reset your password with your user ID to something different via:
    - [POST api/user/reset-password/int:pk/](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-7fe7c511-ca23-4f80-a5db-3a7c46df32f2?tab=body)
- Then, after 5 minutes (temporary time to reset password email), try resetting your password via the same endpoint and same token you used in the previous step, and it should be invalid!
  - [POST api/user/reset-password/int:pk/](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-7fe7c511-ca23-4f80-a5db-3a7c46df32f2?tab=body)

Remember to change back `PASSWORD_RESET_TIMEOUT` to 60 * 60 for a 1 hour limit after testing!

## Preview Image

## Further comments