### PR TITLE
[#487] Refactoring Comment/Reply Sorting Chronological Order

### DIFF
--- a/adoorback/comment/serializers.py
+++ b/adoorback/comment/serializers.py
@@ -57,7 +57,7 @@ class CommentFriendSerializer(CommentBaseSerializer):
 
     def get_replies(self, obj):
         current_user = self.context.get('request', None).user
-        replies = obj.replies.exclude(author_id__in=current_user.user_report_blocked_ids).order_by('-created_at')
+        replies = obj.replies.exclude(author_id__in=current_user.user_report_blocked_ids).order_by('created_at')
 
         def serialize_reply(reply):
             if (reply.author != current_user

--- a/adoorback/note/views.py
+++ b/adoorback/note/views.py
@@ -60,7 +60,7 @@ class NoteComments(generics.ListAPIView):
         return note.note_comments.exclude(
             id__in=blocked_content_ids,
             author_id__in=current_user.user_report_blocked_ids
-        ).order_by('-created_at')
+        ).order_by('created_at')
 
     def list(self, request, *args, **kwargs):
         current_user = self.request.user

--- a/adoorback/qna/views.py
+++ b/adoorback/qna/views.py
@@ -87,7 +87,7 @@ class ResponseComments(generics.ListAPIView):
         return response_.response_comments.exclude(
             id__in=blocked_content_ids,
             author_id__in=current_user.user_report_blocked_ids
-        ).order_by('-created_at')
+        ).order_by('created_at')
 
     def list(self, request, *args, **kwargs):
         comments = self.get_queryset()


### PR DESCRIPTION
## Issue Number:

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

### Implementation
- Sorting implementation changed to 'recent at bottom' for showing the oldest-first comments and replies
- Edited `-created_at` instances in Note and Qna views to `created_at` to display correctly in chronological order

### Testing
- First, login to a tester account (adoor_2) and create a note via `api/notes/` and remember its' note ID:
  - [POST api/user/login](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-787da655-3a39-42c9-b190-377d697d06fc?action=share&source=copy-link&creator=39127770)
  - [POST api/notes/](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-4904597d-dd6b-4bab-b85b-1e7f0c18f3cb?action=share&source=copy-link&creator=39127770)
- Next, login to a different tester account (adoor_3) and add comments via `api/comments/` that you can remember the order of (ex: comment 1, comment 2, comment 3) using the note ID as the target ID and the `target_type` as Note:
  -  [POST api/user/login](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-787da655-3a39-42c9-b190-377d697d06fc?action=share&source=copy-link&creator=39127770)
  - [POST api/comments/](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-2cd1e3cf-b0dd-461a-b8de-f6452251b18c?action=share&source=copy-link&creator=39127770)
- Finally, view the comments for the note ID in chronological order via `api/notes/<int:pk>/comments/`:
  -  [POST api/notes/int:pk/comments/](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-1f00f507-955b-427f-82c2-a5263b52b864?action=share&source=copy-link&creator=39127770)

## Preview Image

## Further comments
