### PR TITLE
[#474] Adding updating visibility functionality for users while editing posts

### DIFF
--- a/adoorback/note/views.py
+++ b/adoorback/note/views.py
@@ -124,6 +124,11 @@ class NoteDetail(generics.RetrieveUpdateDestroyAPIView):
         self.perform_update(serializer)
         return Response(serializer.data)
 
+    def patch(self, request, *args, **kwargs):
+        if 'visibility' in request.data:
+            return self.partial_update(request, *args, **kwargs)
+        return super().patch(request, *args, **kwargs)
+
 
 class DefaultFriendNoteDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = DefaultFriendNoteSerializer

--- a/adoorback/qna/views.py
+++ b/adoorback/qna/views.py
@@ -61,6 +61,11 @@ class ResponseDetail(generics.RetrieveUpdateDestroyAPIView):
         queryset = Response.objects.all()
         return queryset
 
+    def patch(self, request, *args, **kwargs):
+        if 'visibility' in request.data:
+            return self.partial_update(request, *args, **kwargs)
+        return super().patch(request, *args, **kwargs)
+
 
 class ResponseComments(generics.ListAPIView):
     serializer_class = cs.CommentFriendSerializer


### PR DESCRIPTION
## Issue Number:

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

### Implementation
- Added PATCH methods in `NoteDetail` and `ResponseDetail` views to allow users to update visibility of their posts while editing their posts.
  - Utilizes `partial_update` to afford this functionality; should explicitly handle the PATCH endpoint for visibility

### Testing
- First, login as a test account (adoor_3) and find a note ID you want to update the visibility of:
  - [POST api/user/login/](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-787da655-3a39-42c9-b190-377d697d06fc?action=share&source=copy-link&creator=39127770)
  - [POST api/user/me/notes/](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-16a8300d-91b4-45fc-851c-d1d0770e7905?action=share&source=copy-link&creator=39127770)
- Next, using the note ID, call PATCH `api/notes/<int:pk>` and include the JSON key `visibility` as `friends` or `close_friends`, allowing users to modify their visibility while editing a post
  - [PATCH api/notes/int:pk](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-6cff08ff-3488-4992-ae97-43c58f53eb25?action=share&source=copy-link&creator=39127770)


## Preview Image

## Further comments
