### PR TITLE
(#504) Tracking library length limit bug

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -1169,6 +1169,12 @@ class StartSession(generics.CreateAPIView):
     def create(self, request, *args, **kwargs):
         while True:
             session_id = str(uuid.uuid4())
+            
+            # Process if session ID contains a comma 
+            # (use only the part before the comma)
+            if session_id and ',' in session_id:
+                session_id = session_id.split(',')[0]
+                
             try:
                 session = AppSession.objects.create(
                     user=request.user,
@@ -1221,5 +1227,13 @@ class TouchSession(generics.UpdateAPIView):
     
     def get_object(self):
         session_id = self.request.data.get("session_id")
-
+        
+        if not session_id:
+            raise Http404("No session_id provided")
+            
+        # Process if session ID contains a comma 
+        # (use only the part before the comma)
+        if session_id and ',' in session_id:
+            session_id = session_id.split(',')[0]
+        
         return get_object_or_404(AppSession, session_id=session_id, user=self.request.user)

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -47,6 +47,7 @@ from note.serializers import NoteSerializer, DefaultFriendNoteSerializer
 from notification.models import NotificationActor
 from qna.models import ResponseRequest
 from qna.models import Response as _Response
+from tracking.utils import clean_session_key
 
 
 User = get_user_model()
@@ -1170,10 +1171,8 @@ class StartSession(generics.CreateAPIView):
         while True:
             session_id = str(uuid.uuid4())
             
-            # Process if session ID contains a comma 
-            # (use only the part before the comma)
-            if session_id and ',' in session_id:
-                session_id = session_id.split(',')[0]
+            # Clean the session key using the utility function
+            session_id = clean_session_key(session_id)
                 
             try:
                 session = AppSession.objects.create(
@@ -1231,9 +1230,7 @@ class TouchSession(generics.UpdateAPIView):
         if not session_id:
             raise Http404("No session_id provided")
             
-        # Process if session ID contains a comma 
-        # (use only the part before the comma)
-        if session_id and ',' in session_id:
-            session_id = session_id.split(',')[0]
+        # Clean the session key using the utility function
+        session_id = clean_session_key(session_id)
         
         return get_object_or_404(AppSession, session_id=session_id, user=self.request.user)

--- a/adoorback/tracking/handlers.py
+++ b/adoorback/tracking/handlers.py
@@ -3,13 +3,16 @@ from django.core.cache import cache
 from django.conf import settings
 from tracking.models import Visitor
 from tracking.cache import instance_cache_key
+from tracking.utils import clean_session_key
 
 SESSION_COOKIE_AGE = getattr(settings, 'SESSION_COOKIE_AGE')
 
 
 def track_ended_session(sender, request, user, **kwargs):
     try:
-        visitor = Visitor.objects.get(pk=request.session.session_key)
+        # Clean the session key before using it
+        session_key = clean_session_key(request.session.session_key)
+        visitor = Visitor.objects.get(pk=session_key)
     # This should rarely ever occur.. e.g. direct request to logout
     except Visitor.DoesNotExist:
         return

--- a/adoorback/tracking/middleware.py
+++ b/adoorback/tracking/middleware.py
@@ -11,7 +11,7 @@ except ImportError:
     MiddlewareMixin = object
 
 from tracking.models import Visitor, Pageview
-from tracking.utils import get_ip_address, total_seconds
+from tracking.utils import get_ip_address, total_seconds, clean_session_key
 from tracking.settings import (
     TRACK_AJAX_REQUESTS,
     TRACK_ANONYMOUS_USERS,
@@ -79,10 +79,8 @@ class VisitorTrackingMiddleware(MiddlewareMixin):
         # A Visitor row is unique by session_key
         session_key = request.session.session_key
         
-        # If there is a comma in the session key, use only the first part 
-        # (after comma may be token info)
-        if session_key and ',' in session_key:
-            session_key = session_key.split(',')[0]
+        # Clean the session key using the utility function
+        session_key = clean_session_key(session_key)
 
         try:
             visitor = Visitor.objects.get(pk=session_key)

--- a/adoorback/tracking/middleware.py
+++ b/adoorback/tracking/middleware.py
@@ -78,6 +78,11 @@ class VisitorTrackingMiddleware(MiddlewareMixin):
     def _refresh_visitor(self, user, request, visit_time):
         # A Visitor row is unique by session_key
         session_key = request.session.session_key
+        
+        # If there is a comma in the session key, use only the first part 
+        # (after comma may be token info)
+        if session_key and ',' in session_key:
+            session_key = session_key.split(',')[0]
 
         try:
             visitor = Visitor.objects.get(pk=session_key)

--- a/adoorback/tracking/utils.py
+++ b/adoorback/tracking/utils.py
@@ -25,3 +25,14 @@ def get_ip_address(request):
 def total_seconds(delta):
     day_seconds = (delta.days * 24 * 3600) + delta.seconds
     return (delta.microseconds + day_seconds * 10**6) / 10**6
+
+
+def clean_session_key(session_key):
+    """
+    Clean the session key by removing any comma-separated parts.
+    If there is a comma in the session key, use only the first part
+    (after comma may be token info).
+    """
+    if session_key and ',' in session_key:
+        return session_key.split(',')[0]
+    return session_key


### PR DESCRIPTION
## Issue Number: #504

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

Fixed the "value too long for type character varying(255)" error occurring on any requests from APP by:
- Processing session keys to extract only the portion before any comma
- This prevents JWT tokens appended to session keys from exceeding DB field length
- Added comma-handling logic to tracking middleware and session management views

## Preview Image

## Further comments
