### PR TITLE
(#559) add like_count to default feed API

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -1173,9 +1173,9 @@ class FriendFeed(generics.ListAPIView):
 
         page = self.paginate_queryset(notes_before_update)
         if page is not None:
-            serialized_data = NoteSerializer(page, many=True, context=self.get_serializer_context()).data
+            serialized_data = DefaultFriendNoteSerializer(page, many=True, context=self.get_serializer_context()).data
         else:
-            serialized_data = NoteSerializer(notes_before_update, many=True, context=self.get_serializer_context()).data
+            serialized_data = DefaultFriendNoteSerializer(notes_before_update, many=True, context=self.get_serializer_context()).data
 
         # mark all notes as read
         unread_note_ids = queryset.exclude(readers=request.user).values_list("id", flat=True)

--- a/adoorback/note/serializers.py
+++ b/adoorback/note/serializers.py
@@ -14,27 +14,30 @@ from reaction.models import Reaction
 User = get_user_model()
 
 
-class NoteSerializer(AdoorBaseSerializer):
+class BaseNoteSerializer(AdoorBaseSerializer):
     author = serializers.HyperlinkedIdentityField(
-        view_name='user-detail', read_only=True, lookup_field='author', lookup_url_kwarg='username')
+        view_name='user-detail', read_only=True, lookup_field='author', lookup_url_kwarg='username'
+    )
     author_detail = UserMinimalSerializer(source='author', read_only=True)
     images = serializers.SerializerMethodField()
     current_user_read = serializers.SerializerMethodField(read_only=True)
-    current_user_reaction_id_list = serializers.SerializerMethodField(read_only=True)
-    like_reaction_user_sample = serializers.SerializerMethodField(read_only=True)
-    visibility = serializers.ChoiceField(
-        choices=['friends', 'close_friends'],
-        required=True
-    )
 
     def get_current_user_read(self, obj):
-        current_user_id = self.context['request'].user.id
-        return current_user_id in obj.reader_ids
+        return self.context['request'].user.id in obj.reader_ids
 
     def get_images(self, obj):
-        images = obj.images.all().order_by('created_at')
-        return [image.image.url for image in images]
-    
+        return [image.image.url for image in obj.images.all().order_by('created_at')]
+
+    class Meta(AdoorBaseSerializer.Meta):
+        model = Note
+        fields = AdoorBaseSerializer.Meta.fields + ['author', 'author_detail', 'images', 'current_user_read', 'is_edited']
+
+
+class NoteSerializer(BaseNoteSerializer):
+    current_user_reaction_id_list = serializers.SerializerMethodField(read_only=True)
+    like_reaction_user_sample = serializers.SerializerMethodField(read_only=True)
+    visibility = serializers.ChoiceField(choices=['friends', 'close_friends'], required=True)
+
     def get_current_user_reaction_id_list(self, obj):
         current_user_id = self.context['request'].user.id
         content_type_id = get_generic_relation_type(obj.type).id
@@ -42,8 +45,6 @@ class NoteSerializer(AdoorBaseSerializer):
         return [{"id": reaction.id, "emoji": reaction.emoji} for reaction in reactions]
 
     def get_like_reaction_user_sample(self, obj):
-        from account.serializers import UserMinimalSerializer
-
         likes = obj.note_likes.annotate(
             created=F('created_at'),
             like=Value(True, output_field=BooleanField()),
@@ -61,55 +62,33 @@ class NoteSerializer(AdoorBaseSerializer):
             key=lambda x: x['created'],
             reverse=True
         )[:3]
+        
+        return [
+            {**UserMinimalSerializer(User.objects.get(id=item['user']), context=self.context).data, 
+             'like': item['like'], 'reaction': item['reaction']} 
+            for item in combined
+        ]
 
-        serialized_data = []
-        for reaction in combined:
-            user = User.objects.get(id=reaction['user'])
-            user_data = UserMinimalSerializer(user, context=self.context).data
-            user_data['like'] = reaction['like']
-            user_data['reaction'] = reaction['reaction']
-            serialized_data.append(user_data)
-
-        return serialized_data
-
-    class Meta(AdoorBaseSerializer.Meta):
-        model = Note
-        fields = AdoorBaseSerializer.Meta.fields + ['author', 'author_detail', 'images', 'current_user_like_id', 
-                                                    'current_user_read', 'like_reaction_user_sample', 'current_user_reaction_id_list', 'is_edited', 'visibility']
+    class Meta(BaseNoteSerializer.Meta):
+        fields = BaseNoteSerializer.Meta.fields + ['current_user_reaction_id_list', 'like_reaction_user_sample', 'visibility']
 
 
-class DefaultFriendNoteSerializer(AdoorBaseSerializer):
+class DefaultFriendNoteSerializer(BaseNoteSerializer):
     '''
     Friend Note Serializer for default ver.
     1) includes like count even when viewing others' notes
     2) excludes reactions
     '''
     like_count = serializers.SerializerMethodField(read_only=True)
-    author = serializers.HyperlinkedIdentityField(
-        view_name='user-detail', read_only=True, lookup_field='author', lookup_url_kwarg='username')
-    author_detail = UserMinimalSerializer(source='author', read_only=True)
-    images = serializers.SerializerMethodField()
-    current_user_read = serializers.SerializerMethodField(read_only=True)
     like_user_sample = serializers.SerializerMethodField(read_only=True)
 
-    def get_current_user_read(self, obj):
-        current_user_id = self.context['request'].user.id
-        return current_user_id in obj.reader_ids
-
-    def get_images(self, obj):
-        images = obj.images.all().order_by('created_at')
-        return [image.image.url for image in images]
-    
-    def get_like_user_sample(self, obj):
-        from account.serializers import UserMinimalSerializer
-        recent_likes = obj.note_likes.order_by('-created_at')[:3]
-        recent_users = [like.user for like in recent_likes]
-        return UserMinimalSerializer(recent_users, many=True, context=self.context).data
-    
     def get_like_count(self, obj):
         return obj.liked_user_ids.count()
 
-    class Meta(AdoorBaseSerializer.Meta):
-        model = Note
-        fields = AdoorBaseSerializer.Meta.fields + ['author', 'author_detail', 'images', 'current_user_like_id', 
-                                                    'current_user_read', 'like_user_sample', 'is_edited']
+    def get_like_user_sample(self, obj):
+        recent_likes = obj.note_likes.order_by('-created_at')[:3]
+        recent_users = [like.user for like in recent_likes]
+        return UserMinimalSerializer(recent_users, many=True, context=self.context).data
+
+    class Meta(BaseNoteSerializer.Meta):
+        fields = BaseNoteSerializer.Meta.fields + ['like_count', 'like_user_sample']


### PR DESCRIPTION
## Issue Number: #559

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- GET `api/user/feed/` field change
  - `like_count` added
  - `like_user_sample` instead of `like_reaction_user_sample`
  - `visibility` removed

## Preview Image

## Further comments
