### PR TITLE
[#509] Visually Separating Error Logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 # logging
 **/error.log
 **/log.django
+logs/
 
 # python
 adoorback/.python-version

--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -72,7 +72,8 @@ class CurrentUserSerializer(CountryFieldMixin, serializers.HyperlinkedModelSeria
                   'profile_pic', 'question_history', 'url',
                   'profile_image', 'gender', 'date_of_birth',
                   'ethnicity', 'nationality', 'research_agreement', 'pronouns', 'bio', 'persona',
-                  'signature', 'date_of_signature', 'unread_noti', 'noti_time', 'noti_period_days',
+                  'signature', 'date_of_signature', 'unread_noti', 'unread_noti_cnt', 
+                  'noti_time', 'noti_period_days',
                   'timezone', 'current_ver', 'has_changed_pw']
         extra_kwargs = {'password': {'write_only': True}}
 

--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -72,8 +72,7 @@ class CurrentUserSerializer(CountryFieldMixin, serializers.HyperlinkedModelSeria
                   'profile_pic', 'question_history', 'url',
                   'profile_image', 'gender', 'date_of_birth',
                   'ethnicity', 'nationality', 'research_agreement', 'pronouns', 'bio', 'persona',
-                  'signature', 'date_of_signature', 'unread_noti', 'unread_noti_cnt', 
-                  'noti_time', 'noti_period_days',
+                  'signature', 'date_of_signature', 'unread_noti', 'noti_time', 'noti_period_days',
                   'timezone', 'current_ver', 'has_changed_pw']
         extra_kwargs = {'password': {'write_only': True}}
 

--- a/adoorback/adoorback/settings/base.py
+++ b/adoorback/adoorback/settings/base.py
@@ -289,29 +289,29 @@ LOGGING = {
         'error_file': {
             'level': 'ERROR',
             'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(BASE_DIR, 'adoorback', 'error.log'),
+            'filename': os.path.join(BASE_DIR, 'adoorback', 'logs', 'error.log'),
             'when': 'midnight',
-            'interval': 1,  # daily rotation
-            'backupCount': 30,  # keep logs for 30 days
+            'interval': 1,
             'formatter': 'detailed',
+            'suffix': '%Y-%m-%d',
         },
         'info_file': {
             'level': 'INFO',
             'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(BASE_DIR, 'adoorback', 'info.log'),
+            'filename': os.path.join(BASE_DIR, 'adoorback', 'logs', 'info.log'),
             'when': 'midnight',
-            'interval': 1,  # daily rotation
-            'backupCount': 7,  # keep logs for 7 days
+            'interval': 1,
             'formatter': 'verbose',
+            'suffix': '%Y-%m-%d',
         },
         'debug_file': {
             'level': 'DEBUG',
             'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(BASE_DIR, 'adoorback', 'debug.log'),
+            'filename': os.path.join(BASE_DIR, 'adoorback', 'logs', 'debug.log'),
             'when': 'midnight',
-            'interval': 1,  # daily rotation
-            'backupCount': 3,  # keep logs for 3 days
+            'interval': 1,
             'formatter': 'verbose',
+            'suffix': '%Y-%m-%d',
         },
     },
     'loggers': {

--- a/adoorback/adoorback/settings/base.py
+++ b/adoorback/adoorback/settings/base.py
@@ -270,6 +270,10 @@ SESSION_FILE_PATH = os.path.join(BASE_DIR, 'sessions')
 TRACK_ANONYMOUS_USERS = False
 TRACK_IGNORE_STATUS_CODES = [400, 404, 403, 405, 410, 500]
 
+
+LOG_DIR = os.path.join(BASE_DIR, 'logs')
+os.makedirs(LOG_DIR, exist_ok=True)
+
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -289,29 +293,26 @@ LOGGING = {
         'error_file': {
             'level': 'ERROR',
             'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(BASE_DIR, 'adoorback', 'logs', 'error.log'),
+            'filename': os.path.join(LOG_DIR, 'error.log'),
             'when': 'midnight',
             'interval': 1,
             'formatter': 'detailed',
-            'suffix': '%Y-%m-%d',
         },
         'info_file': {
             'level': 'INFO',
             'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(BASE_DIR, 'adoorback', 'logs', 'info.log'),
+            'filename': os.path.join(LOG_DIR, 'info.log'),
             'when': 'midnight',
             'interval': 1,
             'formatter': 'verbose',
-            'suffix': '%Y-%m-%d',
         },
         'debug_file': {
             'level': 'DEBUG',
             'class': 'logging.handlers.TimedRotatingFileHandler',
-            'filename': os.path.join(BASE_DIR, 'adoorback', 'logs', 'debug.log'),
+            'filename': os.path.join(LOG_DIR, 'debug.log'),
             'when': 'midnight',
             'interval': 1,
             'formatter': 'verbose',
-            'suffix': '%Y-%m-%d',
         },
     },
     'loggers': {

--- a/adoorback/adoorback/settings/base.py
+++ b/adoorback/adoorback/settings/base.py
@@ -279,20 +279,61 @@ LOGGING = {
             'style': '{',
             'datefmt': '%Y-%m-%d %H:%M:%S',
         },
+        'detailed': {
+            'format': '\n' + '='*50 + '\n{asctime} [{levelname}]\nLogger: {name}\nPath: {pathname}:{lineno}\nMessage: {message}\n' + '='*50 + '\n',
+            'style': '{',
+            'datefmt': '%Y-%m-%d %H:%M:%S',
+        },
     },
     'handlers': {
-        'file': {
+        'error_file': {
             'level': 'ERROR',
-            'class': 'logging.FileHandler',
-            'filename': 'error.log',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'filename': os.path.join(BASE_DIR, 'adoorback', 'error.log'),
+            'when': 'midnight',
+            'interval': 1,  # daily rotation
+            'backupCount': 30,  # keep logs for 30 days
+            'formatter': 'detailed',
+        },
+        'info_file': {
+            'level': 'INFO',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'filename': os.path.join(BASE_DIR, 'adoorback', 'info.log'),
+            'when': 'midnight',
+            'interval': 1,  # daily rotation
+            'backupCount': 7,  # keep logs for 7 days
+            'formatter': 'verbose',
+        },
+        'debug_file': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'filename': os.path.join(BASE_DIR, 'adoorback', 'debug.log'),
+            'when': 'midnight',
+            'interval': 1,  # daily rotation
+            'backupCount': 3,  # keep logs for 3 days
             'formatter': 'verbose',
         },
     },
     'loggers': {
         'django': {
-            'handlers': ['file'],
-            'level': 'ERROR',
+            'handlers': ['error_file', 'info_file', 'debug_file'],
+            'level': 'DEBUG',
             'propagate': True,
+        },
+        'django.request': {
+            'handlers': ['error_file'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
+        'django.server': {
+            'handlers': ['error_file', 'info_file'],
+            'level': 'INFO',
+            'propagate': False,
+        },
+        'adoorback': {
+            'handlers': ['error_file', 'info_file', 'debug_file'],
+            'level': 'DEBUG',
+            'propagate': False,
         },
     },
 }

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -21,6 +21,8 @@ services:
       '
     volumes:
       - whoami-backend-media:/app/adoorback/adoorback/adoorback/media
+      - ./adoorback/adoorback/logs:/app/adoorback/adoorback/logs
+      - ./error.log:/app/error.log
     healthcheck:
       test:
         [


### PR DESCRIPTION
## Issue Number: #509 

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

- Refactored log entries in `base/settings.py` to log each error message with visual dividers of equal signs (=)
- Separated files into `error_file`, `info_file`, and `debug_file` for improved structure, sets to automatically delete each error periodically
- Should improve overall readability while debugging!

## Preview Image

Separate logs in `error.log` should now look like:
```
==================================================
2025-03-13 10:40:16 [ERROR]
Logger: django.request
Path: /Users/tyzhou/Documents/GitHub/WhoAmI-Today-backend/adoorback/ping/models.py:142
Message: Internal Server Error: /api/ping/user/3/ - AttributeError: 'Notification' object has no attribute 'target_set'
==================================================
```


## Further comments
