### PR TITLE
(#642) modify load_users_from_csv - add country; change password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,7 @@
 # user info
 /adoorback/adoorback/assets/user_list_ko.csv
 /adoorback/adoorback/assets/user_list_us.csv
-/adoorback/adoorback/assets/passwords_ko.csv
-/adoorback/adoorback/assets/passwords_us.csv
+/adoorback/adoorback/assets/created_users.csv
 
 # logging
 **/error.log

--- a/adoorback/adoorback/management/commands/load_users_from_csv.py
+++ b/adoorback/adoorback/management/commands/load_users_from_csv.py
@@ -1,6 +1,4 @@
 import csv
-import random
-import string
 from django.core.management.base import BaseCommand
 from account.models import User, Connection
 import os
@@ -9,112 +7,169 @@ import os
 class Command(BaseCommand):
     help = "Load users from a CSV and create new User instances"
 
-    def add_arguments(self, parser):
-        parser.add_argument('country', type=str, choices=['us', 'ko'], help="Country code: 'us' or 'ko'")
-
     def handle(self, *args, **options):
-        country = options['country']
-        file_path = f"adoorback/assets/user_list_{country}.csv"
-        password_file_path = f"adoorback/assets/passwords_{country}.csv"
+        file_paths = {
+            'us': 'adoorback/assets/user_list_us.csv',
+            'ko': 'adoorback/assets/user_list_ko.csv'
+        }
+        output_file_path = 'adoorback/assets/created_users.csv'
+
+        country_aliases = {
+            'us': ['미국', 'US'],
+            'ko': ['한국', 'Korea']
+        }
 
         group_map = {
             'us': ['group_1', 'group_2'],
             'ko': ['group_3', 'group_4']
         }
         default_groups = ['group_1', 'group_3']
+        fixed_password = 'TempPass123!'
 
-        with open(file_path, mode='r', newline='', encoding='utf-8') as f:
-            reader = csv.reader(f)
-            rows = list(reader)
+        all_rows = []
+        for file_country, file_path in file_paths.items():
+            with open(file_path, mode='r', newline='', encoding='utf-8') as f:
+                reader = csv.reader(f)
+                rows = list(reader)
+                header = rows[0]
+                data_rows = rows[3:]
+                dict_rows = [dict(zip(header, row)) for row in data_rows]
+                for row in dict_rows:
+                    row['file_country'] = file_country
+                all_rows.extend(dict_rows)
 
-        header = rows[0]
-        data_rows = rows[3:]
-        dict_rows = [dict(zip(header, row)) for row in data_rows]
+        print(f'{len(all_rows) = }')
 
-        email_to_row = {row['email']: row for row in dict_rows if 'email' in row}
+        email_to_row = {
+            row['email'].strip().lower(): row
+            for row in all_rows if 'email' in row and row['email'].strip()
+        }
         created_users = {}
         new_users = []
+        skipped_details = []
 
-        group_counts = {group: User.objects.filter(user_group=group).count() for group in group_map[country]}
+        group_counts = {
+            group: User.objects.filter(user_group=group).count()
+            for groups in group_map.values() for group in groups
+        }
 
-        whoami_r = User.objects.get(username='whoami_today_r')
-        whoami_q = User.objects.get(username='whoami_today_q')
+        def get_country(row):
+            value = row.get('country', '').strip()
+            if value:
+                if value in country_aliases['ko']:
+                    return 'ko'
+                elif value in country_aliases['us']:
+                    return 'us'
+            return row.get('file_country')
 
-        def create_user_by_email(email):
+        def create_user_by_email(email, skipped_details):
             email = email.lower()
             if User.objects.filter(email=email).exists():
+                reason = "already exists in DB"
+                skipped_details.append((email, reason))
+                print(f"⛔ {email}: {reason}")
                 return None
 
             if email in created_users:
                 return created_users[email]
 
             row = email_to_row.get(email)
-            if not row or User.objects.filter(email=email).exists():
+            if not row:
+                reason = "row not found in CSV"
+                skipped_details.append((email, reason))
+                print(f"⛔ {email}: {reason}")
                 return None
+
+            created_users[email] = None
+
+            user_country = get_country(row)
+            g1, g2 = group_map[user_country]
 
             friend_email = row.get('friend-email')
             if friend_email == email:
                 friend_email = None
 
             if friend_email and friend_email in email_to_row and friend_email not in created_users:
-                create_user_by_email(friend_email)
+                create_user_by_email(friend_email, skipped_details)
 
-            password = ''.join(random.choices(string.ascii_letters + string.digits, k=12))
-
-            if friend_email and friend_email in created_users:
+            if friend_email and friend_email in created_users and created_users[friend_email]:
                 friend_user = created_users[friend_email]
                 user_group = friend_user.user_group
                 current_ver = friend_user.current_ver
                 invited_from = friend_user
                 user_type = 'indirect'
             else:
-                g1, g2 = group_map[country]
                 user_group = g1 if group_counts[g1] <= group_counts[g2] else g2
                 group_counts[user_group] += 1
                 current_ver = 'default' if user_group in default_groups else 'experiment'
                 invited_from = None
                 user_type = 'direct'
 
-            user = User.objects.create_user(
-                username=email.lower(),
-                email=email.lower(),
-                password=password,
-                user_group=user_group,
-                current_ver=current_ver,
-                invited_from=invited_from,
-                user_type=user_type
-            )
-
-            # 이메일-비밀번호 기록
-            with open(password_file_path, 'a', newline='', encoding='utf-8') as pwfile:
-                writer = csv.writer(pwfile)
-                if os.stat(password_file_path).st_size == 0:
-                    writer.writerow(['email', 'password', 'user_group'])
-                writer.writerow([email.lower(), password, user_group])
-
-            # 👥 친구 연결
-            if current_ver == 'default':
-                Connection.objects.create(
-                    user1=user,
-                    user2=whoami_r,
-                    user1_choice='friend',
-                    user2_choice='friend',
+            try:
+                user = User.objects.create_user(
+                    username=email,
+                    email=email,
+                    password=fixed_password,
+                    user_group=user_group,
+                    current_ver=current_ver,
+                    invited_from=invited_from,
+                    user_type=user_type
                 )
-            elif current_ver == 'experiment':
-                Connection.objects.create(
-                    user1=user,
-                    user2=whoami_q,
-                    user1_choice='friend',
-                    user2_choice='friend',
-                )
+            except Exception as e:
+                reason = f"user creation failed: {str(e)}"
+                skipped_details.append((email, reason))
+                print(f"⛔ {email}: {reason}")
+                return None
+
+            if user_group == 'group_1':
+                whoami_user = User.objects.get(username='whoami_today_r_us')
+            elif user_group == 'group_2':
+                whoami_user = User.objects.get(username='whoami_today_q_us')
+            elif user_group == 'group_3':
+                whoami_user = User.objects.get(username='whoami_today_r_ko')
+            elif user_group == 'group_4':
+                whoami_user = User.objects.get(username='whoami_today_q_ko')
+            else:
+                whoami_user = None
+
+            if whoami_user:
+                try:
+                    Connection.objects.create(
+                        user1=user,
+                        user2=whoami_user,
+                        user1_choice='friend',
+                        user2_choice='friend',
+                    )
+                except Exception as e:
+                    print(f"⚠️ Connection failed for {email}: {str(e)}")
 
             created_users[email] = user
-            new_users.append(row)
+            new_users.append({'email': email, 'user_group': user_group, 'country': user_country})
             return user
 
-        for row in dict_rows:
-            email = row.get('email')
-            if email and email not in created_users and not User.objects.filter(email=email).exists():
-                create_user_by_email(email)
+        for row in all_rows:
+            raw_email = row.get('email', '').strip()
+            if not raw_email:
+                skipped_details.append(("(no email)", "missing or blank email"))
+                print(f"⛔ (no email): missing or blank email")
+                continue
+            email = raw_email.strip().lower()
+            if email not in created_users and not User.objects.filter(email=email).exists():
+                create_user_by_email(email, skipped_details)
 
-        self.stdout.write(self.style.SUCCESS(f'{len(new_users)} new users created. Passwords saved to {password_file_path}.'))
+        file_exists = os.path.exists(output_file_path)
+        with open(output_file_path, 'a', newline='', encoding='utf-8') as outfile:
+            writer = csv.writer(outfile)
+            if not file_exists:
+                writer.writerow(['email', 'user_group', 'country'])
+            for user_info in new_users:
+                writer.writerow([user_info['email'], user_info['user_group'], user_info['country']])
+
+        self.stdout.write(self.style.SUCCESS(f'{len(new_users)} new users created. Info saved to {output_file_path}.'))
+
+        if skipped_details:
+            print(f'\n⛔ 생성되지 않은 유저 {len(skipped_details)}명:')
+            for email, reason in skipped_details:
+                print(f' - {email}: {reason}')
+        else:
+            print('\n✅ 모든 유저가 성공적으로 생성되었습니다!')

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -25,8 +25,7 @@ services:
       - ./error.log:/app/error.log
       - ./adoorback/adoorback/assets/user_list_ko.csv:/app/adoorback/adoorback/assets/user_list_ko.csv
       - ./adoorback/adoorback/assets/user_list_us.csv:/app/adoorback/adoorback/assets/user_list_us.csv
-      - ./adoorback/adoorback/assets/passwords_ko.csv:/app/adoorback/adoorback/assets/passwords_ko.csv
-      - ./adoorback/adoorback/assets/passwords_us.csv:/app/adoorback/adoorback/assets/passwords_us.csv
+      - ./adoorback/adoorback/assets/created_users.csv:/app/adoorback/adoorback/assets/created_users.csv
     healthcheck:
       test:
         [


### PR DESCRIPTION
## Issue Number: #642

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 서버의 `Whoami-Today-backend/adoorback/adoorback/assets` 경로에 `user_list_ko.csv`, `user_list_us.csv`의 이름으로 한국어, 영문 설문 데이터 파일을 업로드한다. (도커 컨테이너 진입하지 않아도 됨)
  - qualtrics에서 export한 csv 파일의 포맷을 기준으로 하기 때문에, 만약 제외하는 유저가 있다면 해당 파일 포맷 내에서 원하는 row만 제거한 후 그 형태 그대로 업로드해야 함
    - (qualtrics export 파일에서 앞에 몇개 row에 실데이터가 아닌 다른 값이 들어가있는데, 이에 대한 고려가 들어가있기 때문..분기 처리 나눠보려 했으나 실패)
    - (칼럼은 email, friend-email, country 세 개만 사용함)
  - scp로 파일 전송도 가능하지만, 직접 들어가서 vi로 user_list_ko.csv, user_list_us.csv 파일을 각각 연 후 안에 내용물을 다 지우고 붙여넣는 것이 조금 더 빠를 듯합니다 (scp 전송시 파일 이름도 바꿔줘야 하기 때문에 좀 더 귀찮아요)
- 백엔드 도커 컨테이너 진입 후, 아래 실행
```
cd adoorback
python manage.py load_users_from_csv
```

### 구체적인 로직 관련 내용
- 이미 존재하는 유저는 (email로 확인) 건너뛰는 로직이 있기 때문에, 만약 한번 돌린 뒤에 추가 유저가 발생하여 또 돌려야 할 경우에도, 전체 데이터를 그대로 업로드해서 다시 진행해도 됨
- 유저 그룹 배정 로직
  - 만약 친구 유저가 있다면 무조건 그 친구와 같은 유저 그룹에 배정됨
  - 그렇지 않다면 해당 국가의 유저 그룹 두 가지 (r, q) 중 인원이 더 적은 그룹에 배정됨
- 생성 후, 자동으로 해당 유저그룹의 whoamitoday mission 계정과 친구가 맺어짐 (둘 다 'friend' 레벨로)
  - 미션 계정 정보는 [여기](https://www.notion.so/jaewon-kim/161f7ff219e581f99880c33fc280d1cd?pvs=4)서 확인

### 비상시 사용하는 커맨드
- (그러면 안되지만) 혹시라도 유저 생성이 잘못됐거나 현재 생성된 유저들 삭제하고 다시 하고 싶다면, 백엔드 도커 컨테이너 진입 후 
```python
python manage.py shell
from safedelete.models import HARD_DELETE
for u in User.all_objects.all():
    if u.id >= [Table plus에서 확인한 방금 생성된 유저들 중 가장 작은 id]:
        u.delete(force_policy=HARD_DELETE)
```
하고 다시 진행
## Preview Image

## Further comments
