### PR TITLE
[#641] Incorrect Question Dates for US users

### DIFF
--- a/adoorback/qna/views.py
+++ b/adoorback/qna/views.py
@@ -24,7 +24,6 @@ from qna.models import Response, Question, ResponseRequest
 
 User = get_user_model()
 
-
 class ResponseCreate(generics.CreateAPIView):
     serializer_class = qs.ResponseSerializer
     permission_classes = [IsAuthenticated, IsNotBlocked]
@@ -230,7 +229,14 @@ class QuestionList(generics.ListCreateAPIView):
         serialized_data = []
         for group in page:
             date_str = group["date"]
-            localized_date = format_date_for_user(date_str, user.timezone)
+            
+            #directly attempt to format the date string
+            try:
+                from datetime import datetime
+                date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
+                localized_date = date_obj.strftime('%B %d, %Y')
+            except Exception:
+                localized_date = date_str
             
             serialized_group = {
                 "date": localized_date,

--- a/adoorback/qna/views.py
+++ b/adoorback/qna/views.py
@@ -210,7 +210,10 @@ class QuestionList(generics.ListCreateAPIView):
         for question in all_questions:
             if question.selected_dates:
                 last_date = question.selected_dates[-1]
-                grouped[last_date].append(question)
+                formatted_date = last_date.strftime('%Y-%m-%d')
+                
+                #try to group by the formatted date string, instead of the date object
+                grouped[formatted_date].append(question)
 
         grouped_ordered = OrderedDict(
             sorted(grouped.items(), key=lambda x: x[0], reverse=True)
@@ -226,8 +229,11 @@ class QuestionList(generics.ListCreateAPIView):
 
         serialized_data = []
         for group in page:
+            date_str = group["date"]
+            localized_date = format_date_for_user(date_str, user.timezone)
+            
             serialized_group = {
-                "date": group["date"],
+                "date": localized_date,
                 "questions": self.serializer_class(
                     group["questions"], many=True, context={"request": request}
                 ).data


### PR DESCRIPTION
## Issue Number: #641 

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

- US-based users are seeing the date of questions one day ahead (e.g. March 23rd when date of question posting was March 22nd).
- Fix attempts to address this by formatting question date display via user's _local timezone_ to try to address this if this may be a timezone issue for US users.

## Preview Image

## Further comments
- As I was going through this, I wasn't quite sure if this may be a backend issue or a frontend issue, as I couldn't think of too much that could be wrong with the current implementation. But let me know your thoughts @njs03332 !
