### PR TITLE
[#699] Add user_list filtering for UserRecommendedFriendsList

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -1095,7 +1095,7 @@ class UserRecommendedFriendsList(generics.ListAPIView):
 
         # Add 10 random users who are experiment participants, not just random users
         participant_emails = set()
-        csv_path = os.path.join(settings.BASE_DIR, 'adoorback', 'assets', 'user_list.csv')
+        csv_path = os.path.join(settings.BASE_DIR, 'assets', 'user_list.csv')
         
         try:
             with open(csv_path, 'r') as f:


### PR DESCRIPTION
## Issue Number: #699 

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- The `UserRecommendedFriendsList` view currently recommends users based on users who have mutual friends with the requester, and random users on the app (e.g. testing accounts + anyone not currently in the study).
- However, this is problematic since we want recommended user friends to only be the experiment participants. 
- Added functionality to first read the `user_list.csv` file, extract email addresses, then filters `potential_random_users` to include only users whose emails are in `user_list.csv`.
  -  Should now ensure that only experiment participants will appear in the randomly recommended friends list, while maintaining the existing functionality for users with mutual friends.

## Preview Image

## Further comments
