### PR TITLE
(#746) add API's for notice feature

### DIFF
--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -34,8 +34,8 @@ urlpatterns = [
     path('<str:username>/notes/default/', views.DefaultUserNoteList.as_view(), name='default-user-note-list'),
     path('<str:username>/responses/', views.UserResponseList.as_view(), name='user-response-list'),
     path('<str:username>/friend-list/', views.FriendFriendList.as_view(), name='friend-friend-list'),
-    path('mark-all-notes-as-read/', views.UserMarkAllNotesAsRead.as_view(), name='user-mark-all-as-read'),
-    path('mark-all-responses-as-read/', views.UserMarkAllResponsesAsRead.as_view(), name='user-mark-all-as-read'),
+    path('mark-all-notes-as-read/', views.UserMarkAllNotesAsRead.as_view(), name='user-mark-all-notes-as-read'),
+    path('mark-all-responses-as-read/', views.UserMarkAllResponsesAsRead.as_view(), name='user-mark-all-responses-as-read'),
 
     # Friend List related
     path('friends/', views.FriendList.as_view(), name='friend-list'),

--- a/adoorback/note/urls.py
+++ b/adoorback/note/urls.py
@@ -10,4 +10,10 @@ urlpatterns = [
     path('<int:pk>/likes/', views.NoteLikes.as_view(), name='note-likes'),  # for default ver.
     path('<int:pk>/interactions/', views.NoteInteractions.as_view(), name='note-interaction-user-list'),
     path('read/', views.NoteRead.as_view(), name='note-read'),
+
+    path('notice/', views.NoticeList.as_view(), name='notice-list'),
+    path('notice/<int:pk>/', views.NoticeDetail.as_view(), name='notice-detail'),
+    path('notice/<int:pk>/comments/', views.NoticeComments.as_view(), name='notice-comments'),
+    path('notice/<int:pk>/interactions/', views.NoticeInteractions.as_view(), name='notice-interaction-user-list'),
+    path('notice/mark-all-notices-as-read/', views.UserMarkAllNoticesAsRead.as_view(), name='user-mark-all-notices-as-read'),
 ]

--- a/adoorback/reaction/views.py
+++ b/adoorback/reaction/views.py
@@ -45,9 +45,6 @@ class ReactionList(generics.ListCreateAPIView):
     def perform_create(self, serializer):
         target, content_type_id, object_id = self.validate_target()
 
-        if target.author != self.request.user and not target.author.is_connected(self.request.user):
-            raise NotFriend()
-
         try:
             serializer.save(user=self.request.user,
                             content_type_id=content_type_id,


### PR DESCRIPTION
## Issue Number: #746

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
- 공지사항 관련 API 구현

<개요>
- 공지사항은 기본적으로 Note 모델을 기반으로 동작
- superuser가 생성한 Note는 공지사항이 됨
- superuser가 로그인한 뒤, 일반 유저처럼 Note를 생성하면 공지사항이 등록되어 모든 유저에게 보이는 구조를 생각함
- 공지사항에 해당하는 Note는 공개범위가 무의미함 (공개범위를 어떻게 설정하든 모든 유저에게, 오직 공지사항 탭에서만 보임)
- superuser는 일반 유저가 Note를 수정, 삭제하는 방식과 똑같이 공지사항을 수정, 삭제할 수 있음

<새로 생성된 API 리스트>
- GET `notes/notice`: 전체 공지사항 리스트 조회
  - [postman](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-7a88664f-3c3f-4bc9-8b5a-bcda46bcb605?action=share&creator=6673035&ctx=documentation)
- GET `notes/notice/<int:pk>/`: 특정 공지사항 detail 조회
  - [postman](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-68ac0728-95ef-435c-9d82-9ea18f26b3f7?action=share&creator=6673035&ctx=documentation)
- GET `notes/notice/<int:pk>/comments/`: 특정 공지사항의 댓글 조회
  - [postman](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-aa44f512-315c-467f-8c1d-b9a9cd59a8fa?action=share&creator=6673035&ctx=documentation)
- GET `notes/notice/<int:pk>/interactions/`: 특정 공지사항의 like, emoji 조회
  - [postman](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-7aa6fd80-967b-479d-b939-8274d03883c7?action=share&creator=6673035&ctx=documentation)
- PATCH `notes/notice/mark-all-notices-as-read/`: 모든 공지사항 읽음 처리
  - [postman](https://diivers.postman.co/workspace/WhoAmI~c2317c3a-2ab1-458e-96b5-01f8ca6b983e/request/6673035-350b114e-66dd-4ae6-9a59-a66bd756204a?action=share&creator=6673035&ctx=documentation)
  - **유저가 공지사항 탭에 접속했을 때 이 API를 콜해주시면 됩니다**

<관련된 기존 API 리스트>
- POST `notes/`: superuser가 콜하는 경우 공지사항 생성됨
- PATCH `notes/<int:id>/`: superuser가 콜하는 경우 공지사항 수정됨
- DELETE `notes/<int:id>/`: superuser가 콜하는 경우 공지사항 삭제됨
- PATCH `notes/read/`: 특정 공지사항 읽음 처리
  - **유저가 공지사항 detail 페이지에 들어오게 되는 경우 note와 동일하게 이 API를 콜해주시면 됩니다**
- POST `likes/`: 공지사항에 좋아요 생성
- POST `comments/`: 공지사항에 댓글 생성
- POST `reactions/<str:ctype>/<int:oid>/`: 공지사항에 이모지 생성

## Preview Image

## Further comments
