### PR TITLE
(#787) add mutual interest & persona to profile API

### DIFF
--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -190,6 +190,8 @@ class UserProfileSerializer(UserMinimalSerializer):
     sent_follow_request_to = serializers.SerializerMethodField(read_only=True)
     received_follow_request_from = serializers.SerializerMethodField(read_only=True)
     pinned_cnt = serializers.SerializerMethodField(read_only=True)
+    mutual_personas = serializers.SerializerMethodField(read_only=True)
+    mutual_interests = serializers.SerializerMethodField(read_only=True)
 
     def get_is_favorite(self, obj):
         request = self.context.get('request')
@@ -218,6 +220,24 @@ class UserProfileSerializer(UserMinimalSerializer):
             mutual_users = User.objects.filter(id__in=mutual_connections)
             return UserMinimalSerializer(mutual_users, many=True).data
         return {}
+
+    def get_mutual_personas(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            current_user_personas = set(request.user.user_personas.all())
+            obj_personas = set(obj.user_personas.all())
+            mutual_personas = current_user_personas & obj_personas
+            return PersonaSerializer(mutual_personas, many=True).data
+        return []
+
+    def get_mutual_interests(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated:
+            current_user_interests = set(request.user.user_interests.all())
+            obj_interests = set(obj.user_interests.all())
+            mutual_interests = current_user_interests & obj_interests
+            return InterestSerializer(mutual_interests, many=True).data
+        return []
 
     def get_are_friends(self, obj):  # does not mean 'friend' in friend & close friend, it means connection
         user = self.context.get('request', None).user
@@ -294,7 +314,7 @@ class UserProfileSerializer(UserMinimalSerializer):
                                                       'friend_count', 'email_verified',
                                                       'is_following', 'is_followed_by',
                                                       'sent_follow_request_to', 'received_follow_request_from',
-                                                      'pinned_cnt']
+                                                      'pinned_cnt', 'mutual_personas', 'mutual_interests']
 
 
 class FriendListSerializer(UserMinimalSerializer):


### PR DESCRIPTION
## Issue Number: #787

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

**Endpoint**: `GET /api/user/<username>/profile/`

## Summary
Added [mutual_personas](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/serializers.py#224-232) and [mutual_interests](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/serializers.py#233-241) fields to the user profile response. These fields return the shared personas and interests between the current user and the profile user.

## Response Format

```json
{
  "id": 123,
  "username": "target_user",
  // ... existing fields ...
  "mutual_personas": [
    {
      "id": 1,
      "content": "lurker"
    },
    {
      "id": 2,
      "content": "coffee_lover"
    }
  ],
  "mutual_interests": [
    {
      "id": 5,
      "content": "Coding"
    },
    {
      "id": 8,
      "content": "Reading"
    }
  ]
}
```

## Field Details

| Field | Type | Description |
|---|---|---|
| [mutual_personas](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/serializers.py#224-232) | `Array<Object>` | List of Persona objects shared between users. Each object has [id](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/serializers.py#78-92) and [content](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/models.py#424-431). |
| [mutual_interests](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/serializers.py#233-241) | `Array<Object>` | List of Interest objects shared between users. Each object has [id](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/serializers.py#78-92) and [content](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/models.py#424-431). |
