### PR TITLE
(#792) fix connections tab APIs

### DIFF
--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -391,6 +391,8 @@ class FriendListSerializer(UserMinimalSerializer):
         return 0
 
     def check_in(self, obj):
+        if self.context.get('hide_check_in'):
+            return None
         user = self.context.get('request', None).user
         check_in = obj.check_in_set.filter(is_active=True).first()
         if check_in and CheckIn.is_audience(check_in, user):

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -1105,13 +1105,20 @@ class FriendList(generics.ListAPIView):
     def get_exception_handler(self):
         return adoor_exception_handler
 
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        query_type = self.request.query_params.get('type')
+        if query_type == 'following':
+            context['hide_check_in'] = True
+        return context
+
     def get_queryset(self):
         user = self.request.user
         friends = user.connected_users
 
         query_type = self.request.query_params.get('type')
 
-        if query_type == 'all':
+        if query_type == 'all' or query_type == 'friends':
             return friends.order_by('username')
         elif query_type == 'close_friends':
             close_friends_ids = Connection.objects.filter(
@@ -1127,6 +1134,8 @@ class FriendList(generics.ListAPIView):
                     target_ids.add(u1_id)
             
             return friends.filter(id__in=target_ids).order_by('username')
+        elif query_type == 'following':
+            return user.following.order_by('username')
         elif query_type == 'has_updates':
             friends = friends.exclude(hidden=True)
             friends_with_updates = [


### PR DESCRIPTION
## Issue Number: #792

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
**Endpoint:** `GET /user/friends/`

The `type` query parameter has been updated with new options.

## Query Parameters (`type`)

### 1. `type=friends` (New)
- **Description**: Returns all connected friends (includes both 'friends' and 'close friends').
- **Behavior**: Equivalent to the existing `type=all`.
- **Response**: List of user objects.

### 2. `type=close_friends` (Unchanged)
- **Description**: Returns only 'close friends'.

### 3. `type=following` (New)
- **Description**: Returns users that the current user is following.
- **Sorting**: Alphabetical by username.
- **Data Constraints**:
  - **Check-in Data**: All check-in related fields (`check_in`, `track_id`, `social_battery`, `description`) will be returned as `null` or empty.
  - **Recent Post**: Returns the latest post (Note or Response) *only if* it is visible to the follower (public or follower-open).

## Summary Table

| `type` param | Returns | Check-in Data | Sorting |
| :--- | :--- | :--- | :--- |
| `friends` | All friends (Friends + Close Friends) | Included (if visible) | Alphabetical |
| `close_friends` | Close Friends only | Included | Alphabetical |
| `following` | Users you follow | **Excluded (Null)** | Alphabetical |
