### PR TITLE
(#770) add latest visibility api

### DIFF
--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     path('me/response-requests/', views.ReceivedResponseRequestList.as_view(), name='received-response-request-list'),
     path('me/search/', views.CurrentUserFriendSearch.as_view(), name='current-user-friend-search'),
     path('me/all-posts/', views.CurrentUserAllPostList.as_view(), name='current-user-all-post-list'),
+    path('me/latest-visibility/', views.CurrentUserLatestVisibility.as_view(), name='current-user-latest-visibility'),
     path('me/interests/', views.CurrentUserInterestUpdate.as_view(), name='current-user-interest-update'),
     path('me/personas/', views.CurrentUserPersonaUpdate.as_view(), name='current-user-persona-update'),
 

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -729,6 +729,35 @@ class UserAllPostList(generics.ListAPIView):
             
         return self.get_paginated_response(serialized_data) if page is not None else Response(serialized_data)
 
+
+class CurrentUserLatestVisibility(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def get(self, request):
+        user = request.user
+        
+        latest_note = Note.objects.filter(author=user).order_by('-created_at').first()
+        latest_response = _Response.objects.filter(author=user).order_by('-created_at').first()
+        
+        if not latest_note and not latest_response:
+            return Response({'visibility': ['close_friends']}, status=200)
+            
+        if latest_note and not latest_response:
+            return Response({'visibility': latest_note.visibility}, status=200)
+            
+        if not latest_note and latest_response:
+            return Response({'visibility': latest_response.visibility}, status=200)
+            
+        # Both exist
+        if latest_note.created_at > latest_response.created_at:
+             return Response({'visibility': latest_note.visibility}, status=200)
+        else:
+             return Response({'visibility': latest_response.visibility}, status=200)
+
+
 class CurrentUserDetail(generics.RetrieveUpdateAPIView):
     serializer_class = CurrentUserSerializer
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
## Issue Number: #770

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

## Get Latest Visibility
Returns the visibility setting of the user's most recent post (Note or Response).

**Endpoint**
`GET /api/user/me/latest-visibility/`

**Response**
*Success (200 OK)*

Returns a JSON object containing the visibility list.

**Example Response**
```json
{
    "visibility": ["public"]
}
```
or
```json
{
    "visibility": ["public", "close_friends"]
}
```

**Notes**
- Logic: Checks the `created_at` timestamp of the user's latest `Note` and `Response`. Returns the visibility of the one that is more recent.
- Default: If the user has created no content (neither Notes nor Responses), the API returns `{"visibility": ["close_friends"]}` (default changed from public).
