### PR TITLE
(#820) make playlist song same as check-in track id

### DIFF
--- a/adoorback/check_in/tests.py
+++ b/adoorback/check_in/tests.py
@@ -49,44 +49,9 @@ class CheckInVisibilityTests(TestCase):
     def test_followers_visibility(self):
         check_in = self.create_check_in(['followers'])
         self.assertFalse(check_in.is_audience(self.stranger))
+        self.assertTrue(check_in.is_audience(self.follower))        
         self.assertTrue(check_in.is_audience(self.follower))
-        # Friends are implicitly connected, but loop logic handles it?
-        # Note logic: is_following checks Follow model. 
-        # Friend is NOT necessarily following in Follow model unless mutually exclusive logic is handled or explicit follow exists.
-        # Wait, Note logic:
-        # if is_friend: check 'friends'
-        # if is_following and not is_friend: check 'followers'
-        # if not is_friend and not is_following: check 'public'
-        
-        # So if visibility is ONLY 'followers', a friend (who is not in 'followers' visibility logic for Friend check) might NOT see it if they are not also following?
-        # Actually `is_following` implementation: `Follow.objects.filter(follower=user, followed=self.author).exists()`
-        
-        # If I am a friend, I am NOT necessarily a follower in `Follow` model (depends on implementation, usually separate).
-        # But usually friends should see 'followers' posts? 
-        # The logic in `is_audience`:
-        # if is_friend: returns True IF 'friends' in visibility.
-        # It does NOT return True if 'followers' in visibility.
-        
-        # So if visibility=['followers'], a Friend (who is not following) will NOT see it.
-        # Is this intended? The Prompt said "Like Response, Note". 
-        # In Note model:
-        # Loop Check Friend: if is_friend: if 'friends' in visibility: return True.
-        # Loop Check Follower: if is_following and not is_friend: if 'followers' in visibility: return True.
-        
-        # So if I mark "Followers only", Friends do NOT see it unless they are also Followers (and `is_friend` check fails? No `is_friend` is usually true).
-        # Actually `is_following and not is_friend`. So if is_friend is True, it SKIPS the follower block.
-        # So Friends CANNOT see "Followers only" posts based on current Note logic.
-        # This implies "Followers" option is strictly for non-connected followers?
-        # OR the user selects multiple? Usually "Followers" implies everyone following?
-        # But the code says: `if is_following and not is_friend`.
-        # So if I am a Friend, I skip that block.
-        # So if visibility is just `['followers']`, a Friend returns False.
-        # Checking `Response` model logic (Step 12):
-        # same logic.
-        # So I will replicate this behavior.
-        
-        self.assertTrue(check_in.is_audience(self.follower))
-        self.assertFalse(check_in.is_audience(self.friend)) # Consistent with Note/Response logic implementation
+        self.assertFalse(check_in.is_audience(self.friend))
         
     def test_friends_visibility(self):
         check_in = self.create_check_in(['friends'])

--- a/adoorback/playlist/serializers.py
+++ b/adoorback/playlist/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from playlist.models import Song
+from check_in.models import CheckIn
 from account.serializers import UserMinimalSerializer
 
 
@@ -8,5 +8,5 @@ class SongSerializer(serializers.ModelSerializer):
     user = UserMinimalSerializer(read_only=True)
 
     class Meta:
-        model = Song
+        model = CheckIn
         fields = ['id', 'user', 'track_id', 'created_at']

--- a/adoorback/playlist/tests.py
+++ b/adoorback/playlist/tests.py
@@ -4,7 +4,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from playlist.models import Song
+from check_in.models import CheckIn
 from account.models import Connection, Follow
 
 User = get_user_model()
@@ -16,43 +16,40 @@ class SongListTestCase(APITestCase):
         self.close_friend = User.objects.create_user(username='close_friend', email='close@test.com', password='password')
         self.followed_user = User.objects.create_user(username='followed', email='followed@test.com', password='password')
         self.stranger = User.objects.create_user(username='stranger', email='stranger@test.com', password='password')
+        
+        # Mutual Friend User (Friend of Friend)
+        self.mutual_friend = User.objects.create_user(username='mutual', email='mutual@test.com', password='password')
 
         self.client.force_authenticate(user=self.user)
 
         # Setup relationships
+        # User <-> Friend
         Connection.objects.create(user1=self.user, user2=self.friend, user1_choice='friend', user2_choice='friend')
+        # User <-> Close Friend
         Connection.objects.create(user1=self.user, user2=self.close_friend, user1_choice='close_friend', user2_choice='friend')
+        # User -> Followed
         Follow.objects.create(follower=self.user, followed=self.followed_user)
+        # Friend <-> Mutual Friend
+        Connection.objects.create(user1=self.friend, user2=self.mutual_friend, user1_choice='friend', user2_choice='friend')
 
-        # Create songs (within 7 days)
-        self.user_song = Song.objects.create(user=self.user, track_id='user_song')
-        self.friend_song = Song.objects.create(user=self.friend, track_id='friend_song')
-        self.close_friend_song = Song.objects.create(user=self.close_friend, track_id='close_friend_song')
-        self.followed_song = Song.objects.create(user=self.followed_user, track_id='followed_song')
-        self.stranger_song = Song.objects.create(user=self.stranger, track_id='stranger_song')
+        # Create CheckIns with songs (within 7 days)
+        # Ensure is_active=True and visibility allows viewing
+        common_defaults = {'is_active': True, 'visibility': ['public', 'friends']}
+        
+        self.user_song = CheckIn.objects.create(user=self.user, track_id='user_song', **common_defaults)
+        self.friend_song = CheckIn.objects.create(user=self.friend, track_id='friend_song', **common_defaults)
+        self.close_friend_song = CheckIn.objects.create(user=self.close_friend, track_id='close_friend_song', **common_defaults)
+        self.followed_song = CheckIn.objects.create(user=self.followed_user, track_id='followed_song', **common_defaults)
+        self.stranger_song = CheckIn.objects.create(user=self.stranger, track_id='stranger_song', **common_defaults)
+        self.mutual_song = CheckIn.objects.create(user=self.mutual_friend, track_id='mutual_song', **common_defaults)
 
         # Old song (older than 7 days)
         old_time = timezone.now() - timedelta(days=8)
-        self.old_song = Song.objects.create(user=self.user, track_id='old_song')
-        self.old_song.created_at = old_time
-        self.old_song.save()
-
-    def test_list_songs_default(self):
-        """Test default behavior (friends + close friends + self)"""
-        response = self.client.get('/api/playlist/feed/')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        data = response.data['results'] if 'results' in response.data else response.data
-        track_ids = [s['track_id'] for s in data]
-        
-        self.assertIn('user_song', track_ids)
-        self.assertIn('friend_song', track_ids)
-        self.assertIn('close_friend_song', track_ids)
-        self.assertNotIn('followed_song', track_ids)
-        self.assertNotIn('stranger_song', track_ids)
-        self.assertNotIn('old_song', track_ids)
+        self.old_song = CheckIn.objects.create(user=self.user, track_id='old_song', is_active=True, visibility=['public'])
+        CheckIn.objects.filter(pk=self.old_song.pk).update(created_at=old_time) # Force update created_at
 
     def test_list_songs_friends(self):
-        """Test type='friends' (same as default)"""
+        """Test type='friends' (Connected users + Self)"""
         response = self.client.get('/api/playlist/feed/?type=friends')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data['results'] if 'results' in response.data else response.data
@@ -61,32 +58,54 @@ class SongListTestCase(APITestCase):
         self.assertIn('user_song', track_ids)
         self.assertIn('friend_song', track_ids)
         self.assertIn('close_friend_song', track_ids)
+        
+        # Followed/Stranger/Mutual should NOT be in 'friends' list unless connected
         self.assertNotIn('followed_song', track_ids)
         self.assertNotIn('stranger_song', track_ids)
+        self.assertNotIn('mutual_song', track_ids)
         self.assertNotIn('old_song', track_ids)
 
-    def test_list_songs_close_friends(self):
-        """Test type='close_friends' (close friends + self)"""
-        response = self.client.get('/api/playlist/feed/?type=close_friends')
+    def test_list_songs_default_mix(self):
+        """Test default behavior (Daily Digest: Mutuals, Strangers, etc. - limit 10)"""
+        # Create more dummy check-ins to test limit if needed, 
+        # but here we have < 10, so it should return all suitable discovery items.
+        response = self.client.get('/api/playlist/feed/') # No type param
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data['results'] if 'results' in response.data else response.data
         track_ids = [s['track_id'] for s in data]
-        
-        self.assertIn('user_song', track_ids)
-        self.assertNotIn('friend_song', track_ids)
-        self.assertIn('close_friend_song', track_ids)
-        self.assertNotIn('followed_song', track_ids)
-        self.assertNotIn('stranger_song', track_ids)
 
-    def test_list_songs_following(self):
-        """Test type='following' (following + self)"""
-        response = self.client.get('/api/playlist/feed/?type=following')
+        # Should NOT contain direct friends
+        self.assertNotIn('user_song', track_ids)
+        self.assertNotIn('friend_song', track_ids)
+        self.assertNotIn('close_friend_song', track_ids)
+        
+        # Should contain discovery items
+        self.assertIn('mutual_song', track_ids)   
+        self.assertIn('stranger_song', track_ids)
+        # Followed users (who are not friends) are also valid candidates for discovery/digest
+        # (matching DiscoverFeed logic which includes 'Following' category)
+        self.assertIn('followed_song', track_ids)
+        
+        # Max limit check (2 discovery + 1 followed = 3)
+        self.assertEqual(len(track_ids), 3)
+        
+    def test_list_songs_mutual_friends(self):
+        """Test type='mutual_friends'"""
+        response = self.client.get('/api/playlist/feed/?type=mutual_friends')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.data['results'] if 'results' in response.data else response.data
         track_ids = [s['track_id'] for s in data]
         
-        self.assertIn('user_song', track_ids)
-        self.assertNotIn('friend_song', track_ids)
-        self.assertNotIn('close_friend_song', track_ids)  # Unless followed, but here strictly checking following relation
-        self.assertIn('followed_song', track_ids)
+        self.assertIn('mutual_song', track_ids)
         self.assertNotIn('stranger_song', track_ids)
+        self.assertNotIn('friend_song', track_ids)
+
+    def test_list_songs_anonymous(self):
+        """Test type='anonymous'"""
+        response = self.client.get('/api/playlist/feed/?type=anonymous')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.data['results'] if 'results' in response.data else response.data
+        track_ids = [s['track_id'] for s in data]
+        
+        self.assertIn('stranger_song', track_ids)
+        self.assertNotIn('mutual_song', track_ids)

--- a/adoorback/playlist/views.py
+++ b/adoorback/playlist/views.py
@@ -1,19 +1,27 @@
 from datetime import timedelta
+from itertools import chain
+import random
+from operator import attrgetter
+
 from django.utils import timezone
 from django.db.models import Q
+from django.contrib.auth import get_user_model
 
 from rest_framework import generics, permissions
 from rest_framework import status
 from rest_framework.response import Response
 
-from playlist.models import Song
+from check_in.models import CheckIn
 from playlist.serializers import SongSerializer
+from account.models import PERSONA_CHOICES, INTEREST_CHOICES_BASE
+
+User = get_user_model()
 
 
 class SongList(generics.ListCreateAPIView):
     """
-    List (Feed): Returns songs from friends/close_friends/self within 7 days.
-    Create: Share a song.
+    List (Feed): Returns songs (CheckIns with track_id) based on 'type' parameter.
+    Create: Share a song (creates a CheckIn).
     """
     serializer_class = SongSerializer
     permission_classes = [permissions.IsAuthenticated]
@@ -21,35 +29,159 @@ class SongList(generics.ListCreateAPIView):
     def get_queryset(self):
         user = self.request.user
         cutoff_date = timezone.now() - timedelta(days=7)
-        filter_type = self.request.query_params.get('type', 'friends')
+        filter_type = self.request.query_params.get('type')
 
-        if filter_type == 'close_friends':
+        # Base filter: Active CheckIns with track_id, within last 7 days
+        base_qs = CheckIn.objects.filter(
+            track_id__isnull=False,
+            created_at__gte=cutoff_date,
+            is_active=True # Assuming only active check-ins should be shown
+        ).exclude(track_id='')
+
+        if filter_type == 'friends':
+            # Existing behavior: Connected users + Self
+            target_ids = user.connected_user_ids + [user.id]
+            return base_qs.filter(user_id__in=target_ids).order_by('-created_at')
+        
+        elif filter_type == 'close_friends':
             target_ids = user.close_friend_ids + [user.id]
+            return base_qs.filter(user_id__in=target_ids).order_by('-created_at')
+
         elif filter_type == 'following':
             target_ids = list(user.following.values_list('id', flat=True)) + [user.id]
-        else:  # default 'all'
-            # Get connected users (friends + close friends)
-            connected_user_ids = user.connected_user_ids
-            # Include self
-            target_ids = connected_user_ids + [user.id]
+            return base_qs.filter(user_id__in=target_ids).order_by('-created_at')
 
-        return Song.objects.filter(
-            user_id__in=target_ids,
-            created_at__gte=cutoff_date
-        )
+        # Discovery Logic
+        exclude_ids = set(user.friend_ids + user.close_friend_ids + user.user_report_blocked_ids + [user.id])
+        
+        # 1. Mutual Friends
+        user_friends = user.connected_users
+        user_friend_ids = set(user_friends.values_list('id', flat=True))
+        mutual_friend_potential_ids = set()
+        for friend in user_friends:
+            friend_of_friend_ids = set(friend.connected_users.values_list('id', flat=True))
+            mutual_friend_potential_ids.update(friend_of_friend_ids)
+        
+        mf_ids = mutual_friend_potential_ids - user_friend_ids - exclude_ids
+        
+        # 2. Mutual Traits
+        user_interests = set(user.user_interests.values_list('id', flat=True))
+        user_personas = set(user.user_personas.values_list('id', flat=True))
+        
+        trait_users_qs = User.objects.filter(
+            Q(user_interests__id__in=user_interests) | Q(user_personas__id__in=user_personas)
+        ).exclude(id__in=exclude_ids)
+        trait_ids = set(trait_users_qs.values_list('id', flat=True))
+
+        # 3. Anonymous (Strangers) - for specific type query
+        stranger_users_qs = User.objects.exclude(
+            id__in=exclude_ids | mf_ids | trait_ids
+        ).exclude(is_superuser=True)
+        stranger_ids = set(stranger_users_qs.values_list('id', flat=True))
+
+        if filter_type == 'mutual_friends':
+            return base_qs.filter(user_id__in=mf_ids, visibility__contains=['public']).order_by('-created_at')
+        elif filter_type == 'mutual_traits':
+            return base_qs.filter(user_id__in=trait_ids, visibility__contains=['public']).order_by('-created_at')
+        elif filter_type == 'anonymous':
+            return base_qs.filter(user_id__in=stranger_ids, visibility__contains=['public']).order_by('-created_at')
+        elif filter_type == 'random':
+             # Random from all non-excluded (simple implementation for param)
+            all_potential_users_qs = User.objects.exclude(id__in=exclude_ids).exclude(is_superuser=True)
+            all_potential_ids = list(all_potential_users_qs.values_list('id', flat=True))
+            if len(all_potential_ids) > 50:
+                query_ids = set(random.sample(all_potential_ids, 50))
+            else:
+                query_ids = set(all_potential_ids)
+            return base_qs.filter(user_id__in=query_ids, visibility__contains=['public']).order_by('-created_at')
+        
+        # --- Default: Daily Digest (Round-Robin 10 items) ---
+        
+        # Fetch Candidates
+        # We need "Songs" (CheckIns), not just Users.
+        
+        def get_candidates(user_ids, limit=20):
+            return list(base_qs.filter(
+                user_id__in=user_ids, 
+                visibility__contains=['public']
+            ).order_by('-created_at')[:limit])
+
+        mf_candidates = get_candidates(mf_ids)
+        trait_candidates = get_candidates(trait_ids)
+        
+        # Strangers for default mix (excludes already found MF/Traits)
+        stranger_candidates = get_candidates(stranger_ids)
+
+        category_candidates = [
+            (mf_candidates, 'mutual_friends'),
+            (trait_candidates, 'mutual_traits'),
+            (stranger_candidates, 'anonymous')
+        ]
+        
+        feed_items = []
+        existing_obj_ids = set()
+        
+        # Step 1: Ensure at least 1 from each category (if exists)
+        for candidates, _ in category_candidates:
+            while candidates:
+                cand = candidates.pop(0)
+                if cand.id not in existing_obj_ids:
+                    feed_items.append(cand)
+                    existing_obj_ids.add(cand.id)
+                    break
+
+        # Step 2: Fill up to 10 in round-robin
+        while len(feed_items) < 10:
+            added_in_round = False
+            for candidates, _ in category_candidates:
+                if len(feed_items) >= 10:
+                    break
+                
+                while candidates:
+                    cand = candidates.pop(0)
+                    if cand.id not in existing_obj_ids:
+                        feed_items.append(cand)
+                        existing_obj_ids.add(cand.id)
+                        added_in_round = True
+                        break
+            
+            if not added_in_round:
+                break
+        
+        # Step 3: Fallback Random if < 10
+        if len(feed_items) < 10:
+            # Get random check-ins from anyone not excluded and not already in feed
+            # Excluding friend_ids, blocked, self (exclude_ids)
+            # And exclude existing_obj_ids
+            fallback_qs = base_qs.filter(visibility__contains=['public'])\
+                .exclude(user_id__in=exclude_ids)\
+                .exclude(id__in=existing_obj_ids)\
+                .order_by('?')[:(10 - len(feed_items))]
+            
+            for item in fallback_qs:
+                feed_items.append(item)
+
+        # Sort by created_at (Newest first)
+        feed_items.sort(key=attrgetter('created_at'), reverse=True)
+        
+        return feed_items
 
     def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+        serializer.save(
+            user=self.request.user, 
+            is_active=True,
+            visibility=['public', 'friends', 'followers'] 
+        )
 
 
 class SongDetail(generics.DestroyAPIView):
     """
-    Destroy: Unshare a song (soft delete).
+    Destroy: Delete a song (CheckIn).
     """
-    queryset = Song.objects.all()
+    queryset = CheckIn.objects.all()
     serializer_class = SongSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_queryset(self):
-        # Allow user to delete only their own songs
-        return Song.objects.filter(user=self.request.user)
+        # Allow user to delete only their own check-ins
+        return CheckIn.objects.filter(user=self.request.user)


### PR DESCRIPTION
## Issue Number: #820

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
# Playlist API Changes

## Overview
The **Playlist Feed** has been integrated with **Check-Ins**. 
- Songs are now sourced directly from User Check-Ins (`track_id` in Check-In).
- The default feed logic has changed to a **Daily Digest (Discovery Mix)**.
- New filter types are available.

---

## 🎵 Playlist Feed (`GET /api/playlist/feed/`)

### **1. Default Behavior (Daily Digest)**
- **Endpoint**: `GET /api/playlist/feed/` (No parameters)
- **Logic**: Returns a curated list of **up to 10 items**.
    - **Content**: Mix of **Mutual Friends**, **Users with Similar Traits**, and **Strangers**.
    - **Excluded**: Your direct friends are **excluded** (to promote discovery).
    - **Sorting**: Newest first (`created_at` desc).
- **Use Case**: The main "Discovery" feed view.

### **2. Filter Types ([type](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/models.py#510-513) parameter)**
You can request specific feeds using the [type](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/models.py#510-513) query parameter.

| Parameter ([type](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/models.py#510-513)) | Description |
| :--- | :--- |
| [mutual_friends](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/playlist/tests.py#92-102) | Returns songs from **Friends of Friends** (Discovery). |
| `mutual_traits` | Returns songs from users with **similar Interests/Personas** (Discovery). |
| [anonymous](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/views.py#167-174) | Returns songs from **Strangers** (No visible connection). |
| [random](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/account/models.py#136-139) | Returns random songs from non-connected users. |

---

## 📦 Response Object Structure
The structure of the song object remains largely compatible, but the [id](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/check_in/models.py#47-50) now corresponds to a **Check-In ID**.

```json
{
  "count": 10,
  "next": null,
  "previous": null,
  "results": [
    {
      "id": 123,                  // CheckIn ID
      "user": {                   // UserMinimalSerializer
        "id": 45,
        "username": "johndoe",
        "profile_pic": "..."
      },
      "track_id": "spotify:track:..." // The Song ID
      "created_at": "2024-01-28T12:00:00Z"
    },
    ...
  ]
}
```

## ✅ Creating a Song (`POST /api/playlist/feed/`)
- Creating a song now creates a **Check-In** entry.
- **Default Visibility**: `['public', 'friends', 'followers']`
    - This ensures the song is visible in the Discovery Feed (Public) and to Friends/Followers.
