### PR TITLE
(#828) add API to check latest visibility setting for check-in

### DIFF
--- a/adoorback/check_in/urls.py
+++ b/adoorback/check_in/urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path('', views.CurrentCheckIn.as_view(), name='current-check-in'),
     path('<int:pk>/', views.CheckInDetail.as_view(), name='check-in-detail'),
     path('read/<int:pk>/', views.CheckInRead.as_view(), name='check-in-read'),
+    path('latest-visibility/', views.CurrentUserLatestCheckInVisibility.as_view(), name='current-user-latest-check-in-visibility'),
 ]

--- a/adoorback/check_in/views.py
+++ b/adoorback/check_in/views.py
@@ -102,3 +102,19 @@ class CheckInRead(generics.UpdateAPIView):
         instance.readers.add(current_user)
         serializer = self.get_serializer(instance)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class CurrentUserLatestCheckInVisibility(generics.RetrieveAPIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def get(self, request):
+        user = request.user
+        latest_check_in = CheckIn.objects.filter(user=user).order_by('-created_at').first()
+        
+        if latest_check_in:
+            return Response({'visibility': latest_check_in.visibility}, status=status.HTTP_200_OK)
+        else:
+            return Response({'visibility': ['public', 'followers', 'friends']}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Issue Number: #828

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
# API Changes: Check-In Visibility

## New Endpoint: Get Latest Check-In Visibility

**URL**: `/api/check_in/latest-visibility/`  
**Method**: `GET`  
**Authentication**: Required

### Description
Retrieves the visibility setting of the current user's most recent Check-In. This is used to preserve the user's privacy preference across sessions.

### Response `200 OK`
Returns a JSON object containing the [visibility](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/check_in/tests.py#41-48) list.

```json
{
  "visibility": ["public", "followers", "friends"]
}
```

### Usage Note for Frontend
When a user accesses the **Check-In creation page**, make a request to this endpoint. Use the returned [visibility](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/check_in/tests.py#41-48) values to set the **default selected state** of the visibility options.

> [!NOTE]
> If the user has no prior Check-Ins, the API defaults to `['public', 'followers', 'friends']` (different from Note/Response defaults).
