### PR TITLE
(#832, #833) make visibility hierarchical

### DIFF
--- a/adoorback/account/models.py
+++ b/adoorback/account/models.py
@@ -818,18 +818,6 @@ def connection_removed(instance, **kwargs):
 
 
 @transaction.atomic
-@receiver(post_save, sender=Connection)
-def stop_following_on_friend_connection(instance, **kwargs):
-    if not instance.deleted:
-        user1 = instance.user1
-        user2 = instance.user2
-
-        # Delete any existing Follow objects between the two users
-        Follow.objects.filter(follower=user1, followed=user2).delete(force_policy=HARD_DELETE)
-        Follow.objects.filter(follower=user2, followed=user1).delete(force_policy=HARD_DELETE)
-
-
-@transaction.atomic
 @receiver(post_save, sender=FriendRequest)
 def create_connection_noti(created, instance, **kwargs):
     if instance.deleted:
@@ -879,6 +867,10 @@ def create_connection_noti(created, instance, **kwargs):
             user1_upgrade_time=timezone.now() if instance.requester_choice == 'close_friend' else None,
             user2_upgrade_time=timezone.now() if instance.requestee_choice == 'close_friend' else None,
         )
+
+        # auto-follow logic
+        Follow.objects.get_or_create(follower=requester, followed=requestee)
+        Follow.objects.get_or_create(follower=requestee, followed=requester)
 
         # make chat room
         from chat.models import ChatRoom

--- a/adoorback/account/tests_update_profile.py
+++ b/adoorback/account/tests_update_profile.py
@@ -1,0 +1,55 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.urls import reverse
+from notification.models import Notification, NotificationActor
+from django.contrib.contenttypes.models import ContentType
+
+User = get_user_model()
+
+class UserProfileUpdateTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username='old_username', email='test@example.com', password='password')
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse('current-user-detail')
+
+    def test_username_update_success(self):
+        # Create a notification that should be updated
+        # Assuming there is a notification related to friendship
+        # The logic filters friendship_originated_notis with target_type=User
+        
+        # We need another user to be the target or involved
+        other_user = User.objects.create_user(username='friend', email='friend@example.com', password='password')
+        
+        # Create a notification where 'user' is the actor (origin) 
+        # and it is a friendship notification (target is User)
+        # Note: friendship_originated_notis means notification.origin = user
+        user_ct = ContentType.objects.get_for_model(User)
+        
+        noti = Notification.objects.create(
+            user=other_user, # The receiver of notification
+            origin_id=self.user.id,
+            origin_type=user_ct,
+            target_id=other_user.id, # Target is the other user (e.g. "became friends with X")
+            target_type=user_ct,
+            message_ko="Test Noti",
+            message_en="Test Noti",
+            redirect_url=f"/users/{self.user.username}"
+        )
+        NotificationActor.objects.create(user=self.user, notification=noti)
+        
+        # Action: Update username
+        new_username = 'new_username'
+        data = {'username': new_username}
+        response = self.client.patch(self.url, data)
+        
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, new_username)
+        
+        # Check if notification redirect_url is updated
+        noti.refresh_from_db()
+        expected_url = f"/users/{new_username}"
+        self.assertEqual(noti.redirect_url, expected_url)

--- a/adoorback/check_in/models.py
+++ b/adoorback/check_in/models.py
@@ -61,46 +61,44 @@ class CheckIn(AdoorTimestampedModel, SafeDeleteModel):
         if self.user == user:
             return True
 
-        is_close_friend = user.is_close_friend(self.user)
-        connection = Connection.get_connection_between(self.user, user)
-        is_friend = connection is not None
-
-        # Check Close Friend
-        if is_close_friend:
-            if self.user == connection.user1:
-                update_past_posts = connection.user1_update_past_posts
-                upgrade_time = connection.user1_upgrade_time
-            else:
-                update_past_posts = connection.user2_update_past_posts
-                upgrade_time = connection.user2_upgrade_time
-
-            can_see_as_cf = False
-            if update_past_posts:
-                can_see_as_cf = True
-            elif upgrade_time is None:  # users were close friends from the beginning
-                can_see_as_cf = True
-            elif self.created_at > upgrade_time:
-                can_see_as_cf = True
+        # Hierarchical Visibility Checks
+        if 'public' in self.visibility:
+            return True
             
-            if can_see_as_cf and 'close_friends' in self.visibility:
+        # Check Follower
+        if 'followers' in self.visibility:
+            if user.is_following(self.user):
                 return True
-        
+                
         # Check Friend
-        if is_friend:
-            if 'friends' in self.visibility:
-                return True
+        if 'friends' in self.visibility:
+             # Check for connection
+             if Connection.objects.filter(
+                (models.Q(user1=self.user) & models.Q(user2=user)) | 
+                (models.Q(user1=user) & models.Q(user2=self.user))
+             ).exists():
+                 return True
+                 
+        # Check Close Friend
+        if 'close_friends' in self.visibility:
+            if user.is_close_friend(self.user):
+                # Upgrade logic
+                connection = Connection.get_connection_between(self.user, user)
+                if connection:
+                    if self.user == connection.user1:
+                        update_past_posts = connection.user1_update_past_posts
+                        upgrade_time = connection.user1_upgrade_time
+                    else:
+                        update_past_posts = connection.user2_update_past_posts
+                        upgrade_time = connection.user2_upgrade_time
+
+                    if update_past_posts:
+                        return True
+                    elif upgrade_time is None:
+                        return True
+                    elif self.created_at > upgrade_time:
+                        return True
         
-        # Check Follower (Mutually Exclusive: Not Connected)
-        is_following = user.is_following(self.user)
-        if is_following and not is_friend:
-             if 'followers' in self.visibility:
-                return True
-
-        # Check Public (Mutually Exclusive: Not Connected, Not Following)
-        if not is_friend and not is_following:
-            if 'public' in self.visibility:
-                return True
-
         return False
 
     class Meta:

--- a/adoorback/check_in/serializers.py
+++ b/adoorback/check_in/serializers.py
@@ -26,8 +26,8 @@ class MyCheckInSerializer(CheckInBaseSerializer):
         }
 
     def validate_visibility(self, value):
-        if len(value) == 0:
-            raise serializers.ValidationError("visibility field is required.")
+        if len(value) != 1:
+            raise serializers.ValidationError("Please select exactly one visibility option.")
         return value
 
 

--- a/adoorback/note/models.py
+++ b/adoorback/note/models.py
@@ -105,46 +105,37 @@ class Note(AdoorModel, SafeDeleteModel):
         if self.author == user:
             return True
 
-        is_close_friend = user.is_close_friend(self.author)
-        connection = Connection.get_connection_between(self.author, user)
-        is_friend = connection is not None
-
-        # Check Close Friend
-        if is_close_friend:
-            if self.author == connection.user1:
-                update_past_posts = connection.user1_update_past_posts
-                upgrade_time = connection.user1_upgrade_time
-            else:
-                update_past_posts = connection.user2_update_past_posts
-                upgrade_time = connection.user2_upgrade_time
-
-            can_see_as_cf = False
-            if update_past_posts:
-                can_see_as_cf = True
-            elif upgrade_time is None:  # users were close friends from the beginning
-                can_see_as_cf = True
-            elif self.created_at > upgrade_time:
-                can_see_as_cf = True
+        # Hierarchical Visibility Checks
+        if 'public' in self.visibility:
+            return True
             
-            if can_see_as_cf and 'close_friends' in self.visibility:
+        if 'followers' in self.visibility:
+            if user.is_following(self.author):
                 return True
-        
-        # Check Friend
-        if is_friend:
-            if 'friends' in self.visibility:
-                return True
-        
-        # Check Follower (Mutually Exclusive: Not Connected)
-        is_following = user.is_following(self.author)
-        if is_following and not is_friend:
-             if 'followers' in self.visibility:
-                return True
+                
+        if 'friends' in self.visibility:
+             if user.is_connected(self.author):
+                 return True
+                 
+        if 'close_friends' in self.visibility:
+            if user.is_close_friend(self.author):
+                # Upgrade logic
+                connection = Connection.get_connection_between(self.author, user)
+                if connection:
+                    if self.author == connection.user1:
+                        update_past_posts = connection.user1_update_past_posts
+                        upgrade_time = connection.user1_upgrade_time
+                    else:
+                        update_past_posts = connection.user2_update_past_posts
+                        upgrade_time = connection.user2_upgrade_time
 
-        # Check Public (Mutually Exclusive: Not Connected, Not Following)
-        if not is_friend and not is_following:
-            if 'public' in self.visibility:
-                return True
-
+                    if update_past_posts:
+                        return True
+                    elif upgrade_time is None:
+                        return True
+                    elif self.created_at > upgrade_time:
+                        return True
+        
         return False
 
     class Meta:

--- a/adoorback/note/serializers.py
+++ b/adoorback/note/serializers.py
@@ -78,6 +78,11 @@ class NoteSerializer(BaseNoteSerializer):
     like_reaction_user_sample = serializers.SerializerMethodField(read_only=True)
     visibility = VisibilityField(choices=['friends', 'close_friends', 'public', 'followers'], required=True)
 
+    def validate_visibility(self, value):
+        if len(value) != 1:
+            raise serializers.ValidationError("Please select exactly one visibility option.")
+        return list(value)
+
     def get_current_user_reaction_id_list(self, obj):
         current_user_id = self.context['request'].user.id
         content_type_id = get_generic_relation_type(obj.type).id
@@ -122,6 +127,11 @@ class DefaultFriendNoteSerializer(BaseNoteSerializer):
     like_count = serializers.SerializerMethodField(read_only=True)
     like_user_sample = serializers.SerializerMethodField(read_only=True)
     visibility = VisibilityField(choices=['friends', 'close_friends', 'public', 'followers'], required=True)
+
+    def validate_visibility(self, value):
+        if len(value) != 1:
+            raise serializers.ValidationError("Please select exactly one visibility option.")
+        return list(value)
 
     def get_like_count(self, obj):
         return obj.liked_user_ids.count()

--- a/adoorback/pin/views.py
+++ b/adoorback/pin/views.py
@@ -55,3 +55,18 @@ class UserPinList(generics.ListAPIView):
     def get_queryset(self):
         username = self.kwargs.get('username')
         return Pin.objects.filter(user__username=username).order_by('-created_at')
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        visible_pins = []
+        for pin in queryset:
+            if pin.content_object and pin.content_object.is_audience(request.user):
+                visible_pins.append(pin)
+        
+        page = self.paginate_queryset(visible_pins)
+        if page is not None:
+            serializer = self.get_serializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(visible_pins, many=True)
+        return Response(serializer.data)

--- a/adoorback/qna/models.py
+++ b/adoorback/qna/models.py
@@ -149,51 +149,37 @@ class Response(AdoorModel, SafeDeleteModel):
         if self.author == user:
             return True
             
-        is_close_friend = user.is_close_friend(self.author)
-        is_friend = Connection.objects.filter(
-            (models.Q(user1=self.author) & models.Q(user2=user)) | 
-            (models.Q(user1=user) & models.Q(user2=self.author))
-        ).exists()
-        is_following = user.is_following(self.author)
-
-        # Check Close Friend
-        if is_close_friend:
-            # Upgrade logic for close friends
-            connection = Connection.get_connection_between(self.author, user)
-            if connection:  # Should exist if close friend
-                if self.author == connection.user1:
-                    update_past_posts = connection.user1_update_past_posts
-                    upgrade_time = connection.user1_upgrade_time
-                else:
-                    update_past_posts = connection.user2_update_past_posts
-                    upgrade_time = connection.user2_upgrade_time
-
-                can_see_as_cf = False
-                if update_past_posts:
-                    can_see_as_cf = True
-                elif upgrade_time is None:
-                    can_see_as_cf = True
-                elif self.created_at > upgrade_time:
-                    can_see_as_cf = True
+        # Hierarchical Visibility Checks
+        if 'public' in self.visibility:
+            return True
+            
+        if 'followers' in self.visibility:
+            if user.is_following(self.author):
+                return True
                 
-                if can_see_as_cf and 'close_friends' in self.visibility:
-                    return True
+        if 'friends' in self.visibility:
+             if user.is_connected(self.author):
+                 return True
+                 
+        if 'close_friends' in self.visibility:
+            if user.is_close_friend(self.author):
+                # Upgrade logic
+                connection = Connection.get_connection_between(self.author, user)
+                if connection:
+                    if self.author == connection.user1:
+                        update_past_posts = connection.user1_update_past_posts
+                        upgrade_time = connection.user1_upgrade_time
+                    else:
+                        update_past_posts = connection.user2_update_past_posts
+                        upgrade_time = connection.user2_upgrade_time
 
-        # Check Friend
-        if is_friend:
-            if 'friends' in self.visibility:
-                return True
-
-        # Check Follower (Mutually Exclusive: Not Connected)
-        if is_following and not is_friend:
-             if 'follower' in self.visibility:
-                return True
-
-        # Check Public (Mutually Exclusive: Not Connected, Not Following)
-        if not is_friend and not is_following:
-            if 'public' in self.visibility:
-                return True
-
+                    if update_past_posts:
+                        return True
+                    elif upgrade_time is None:
+                        return True
+                    elif self.created_at > upgrade_time:
+                        return True
+        
         return False
 
 

--- a/adoorback/qna/serializers.py
+++ b/adoorback/qna/serializers.py
@@ -49,13 +49,15 @@ class ResponseSerializer(AdoorBaseSerializer):
     current_user_reaction_id_list = serializers.SerializerMethodField(read_only=True)
     like_reaction_user_sample = serializers.SerializerMethodField(read_only=True)
     visibility = serializers.MultipleChoiceField(
-        choices=['public', 'follower', 'friends', 'close_friends'],
+        choices=['public', 'followers', 'friends', 'close_friends'],
         required=True
     )
     pinned = serializers.SerializerMethodField(read_only=True)
     pin_id = serializers.SerializerMethodField(read_only=True)
 
     def validate_visibility(self, value):
+        if len(value) != 1:
+            raise serializers.ValidationError(_("Please select exactly one visibility option."))
         return list(value)
 
     def get_current_user_read(self, obj):


### PR DESCRIPTION
## Issue Number: #832, #833

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?
## 1. Visibility Field Update
The behavior of the [visibility](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/qna/serializers.py#58-62) field has changed to support a strictly hierarchical structure.

- **Endpoint Impact**: Creating or Editing [Response](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/qna/models.py#80-184), [Note](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/note/models.py#43-145), and [CheckIn](file:///Users/yurikim/Documents/git/WhoamI-Today-backend/adoorback/check_in/models.py#18-108).
- **Field Format**: `Array<String>` (Must contain **exactly one** item).
  - ✅ Correct: `["public"]`, `["friends"]`
  - ❌ Incorrect: `["public", "friends"]` (Multiple), `[]` (Empty), `"public"` (String)
- **Available Options** (Case-sensitive):
  - `"public"`: Visible to everyone.
  - `"followers"`: Visible to followers (includes friends).
  - `"friends"`: Visible to connected friends (includes close friends).
  - `"close_friends"`: Visible to close friends only.

> **Note**: While the API still accepts an array for legacy compatibility, the backend strictly validates that only **one option** is selected. Please update the UI to use Radio Buttons or a Single Select Dropdown instead of Checkboxes.

---

## 2. Friendship & Following Relationship
The relationship logic has been simplified.

- **Auto-Follow**: When two users become **Friends** (Connection is created), they will automatically **Follow** each other.
  - Frontend Action: No need to send a separate "Follow" API request after a user accepts a friend request.
- **Coexistence**: Friendship and Follow statuses now coexist.
  - Previously: Being Friends meant you were *not* following (mutually exclusive).
  - Now: Being Friends implies you *are* following.

---

## 3. Pinned Posts Filtering
- **Endpoint**: `GET /api/pin/user/<username>/` (User Pin List)
- **Behavior**: The detailed list of pinned posts is now **automatically filtered** based on the viewer's visibility permissions.
- **Impact**: If a user pins a "Close Friends only" post, a viewer who is not a close friend will simply not see that item in the returned list. 