### PR TITLE
(#850) implement connection tab changes

### DIFF
--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -337,7 +337,6 @@ class FriendListSerializer(UserMinimalSerializer):
     description = serializers.SerializerMethodField(read_only=True)
     unread_ping_count = serializers.SerializerMethodField(read_only=True)
     social_battery = serializers.SerializerMethodField(read_only=True)
-    recent_post = serializers.SerializerMethodField(read_only=True)
 
     def get_url(self, obj):
         return settings.BASE_URL + reverse('user-detail', kwargs={'username': obj.username})
@@ -366,18 +365,11 @@ class FriendListSerializer(UserMinimalSerializer):
         return None
 
     def get_current_user_read(self, obj):
-        from check_in.serializers import CheckInBaseSerializer
         responses = self.responses(obj)
         notes = self.notes(obj)
-        check_in = self.check_in(obj)
-        if check_in:
-            check_in_data = CheckInBaseSerializer(check_in, read_only=True, context=self.context).data
-        else:
-            check_in_data = {}
 
         current_user_read = not any(not response['current_user_read'] for response in responses) \
-                            and not any(not note['current_user_read'] for note in notes) \
-                            and not (check_in_data and not check_in_data['current_user_read'])
+                            and not any(not note['current_user_read'] for note in notes)
         return current_user_read
     
     def get_unread_cnt(self, obj):
@@ -444,72 +436,11 @@ class FriendListSerializer(UserMinimalSerializer):
             return ping_room.pings.filter(receiver=user, is_read=False).count()
         return 0
 
-    def get_recent_post(self, obj):
-        responses = self.responses(obj)
-        notes = self.notes(obj)
-        
-        # Combine and sort by created_at descending
-        all_posts = []
-        for r in responses:
-            all_posts.append({
-                'type': 'Response',
-                'id': r['id'],
-                'content': r['content'],
-                'created_at': r['created_at'],
-                'question': r.get('question'), # Include full question object
-                'current_user_like_id': r.get('current_user_like_id'),
-                'current_user_reaction_id_list': r.get('current_user_reaction_id_list'),
-                'like_reaction_user_sample': r.get('like_reaction_user_sample'),
-                'is_read': r.get('current_user_read'),
-                'comment_count': r.get('comment_count'),
-            })
-        for n in notes:
-            all_posts.append({
-                'type': 'Note',
-                'id': n['id'],
-                'content': n['content'],
-                'created_at': n['created_at'],
-                'current_user_like_id': n.get('current_user_like_id'),
-                'current_user_reaction_id_list': n.get('current_user_reaction_id_list'),
-                'like_reaction_user_sample': n.get('like_reaction_user_sample'),
-                'is_read': n.get('current_user_read'),
-                'images': n.get('images'),
-                'comment_count': n.get('comment_count'),
-            })
-        
-        if not all_posts:
-            return None
-            
-        # Sort by created_at desc (assuming ISO string format sorts correctly)
-        all_posts.sort(key=lambda x: x['created_at'], reverse=True)
-        recent = all_posts[0]
-        
-        # Format output
-        preview = recent['content'][:50]
-        
-        data = {
-            'type': recent['type'],
-            'id': recent['id'],
-            'preview_content': preview,
-            'created_at': recent['created_at'],
-            'current_user_like_id': recent.get('current_user_like_id'),
-            'current_user_reaction_id_list': recent.get('current_user_reaction_id_list'),
-            'like_reaction_user_sample': recent.get('like_reaction_user_sample'),
-            'is_read': recent.get('is_read'),
-            'images': recent.get('images', []),
-            'comment_count': recent.get('comment_count'),
-        }
-        
-        if recent['type'] == 'Response':
-             data['question'] = recent.get('question')
-             
-        return data
-
     class Meta(UserMinimalSerializer.Meta):
         model = User
         fields = UserMinimalSerializer.Meta.fields + ['is_favorite', 'is_hidden', 'connection_status', 'current_user_read',
                                                       'unread_cnt', 'bio', 'track_id', 'description', 'unread_ping_count',
-                                                      'recent_post', 'social_battery']
+                                                      'social_battery']
 
 
 class FriendFriendListSerializer(UserMinimalSerializer):

--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
     path('<str:username>/responses/', views.UserResponseList.as_view(), name='user-response-list'),
     path('<str:username>/friend-list/', views.FriendFriendList.as_view(), name='friend-friend-list'),
     path('<str:username>/all-posts/', views.UserAllPostList.as_view(), name='user-all-post-list'),
+    path('<str:username>/unread-posts/', views.UserUnreadPostList.as_view(), name='user-unread-post-list'),
     path('mark-all-notes-as-read/', views.UserMarkAllNotesAsRead.as_view(), name='user-mark-all-notes-as-read'),
     path('mark-all-responses-as-read/', views.UserMarkAllResponsesAsRead.as_view(), name='user-mark-all-responses-as-read'),
 

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -717,6 +717,7 @@ class UserAllPostList(generics.ListAPIView):
         page = self.paginate_queryset(combined_items)
         objects_to_serialize = page if page is not None else combined_items
         
+        user = request.user
         serialized_data = []
         for obj in objects_to_serialize:
             if isinstance(obj, Note):
@@ -726,8 +727,55 @@ class UserAllPostList(generics.ListAPIView):
                 serialized = ResponseSerializer(obj, context=self.get_serializer_context()).data
                 serialized['type'] = 'Response' # Optional
             serialized_data.append(serialized)
-            
+
+        for obj in objects_to_serialize:
+            obj.readers.add(user)
+
         return self.get_paginated_response(serialized_data) if page is not None else Response(serialized_data)
+
+
+class UserUnreadPostList(generics.ListAPIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def list(self, request, *args, **kwargs):
+        user = request.user
+        author_username = self.kwargs.get('username')
+        author = get_object_or_404(User, username=author_username)
+
+        all_notes = Note.objects.filter(author=author)
+        note_ids = [note.id for note in all_notes if note.is_audience(user)]
+        unread_notes = list(
+            Note.objects.filter(id__in=note_ids).exclude(readers=user).order_by('-created_at').distinct()
+        )
+
+        all_responses = _Response.objects.filter(author=author).order_by('-created_at')
+        response_ids = [response.id for response in all_responses if response.is_audience(user)]
+        unread_responses = list(
+            _Response.objects.filter(id__in=response_ids).exclude(readers=user).distinct()
+        )
+
+        combined = sorted(chain(unread_notes, unread_responses), key=lambda x: x.created_at, reverse=True)
+
+        serialized_data = []
+        for obj in combined:
+            if isinstance(obj, Note):
+                serialized = NoteSerializer(obj, context=self.get_serializer_context()).data
+                serialized['type'] = 'Note'
+            elif isinstance(obj, _Response):
+                serialized = ResponseSerializer(obj, context=self.get_serializer_context()).data
+                serialized['type'] = 'Response'
+            serialized_data.append(serialized)
+
+        # Mark all as read after fetching
+        for obj in unread_notes:
+            obj.readers.add(user)
+        for obj in unread_responses:
+            obj.readers.add(user)
+
+        return Response(serialized_data)
 
 
 class CurrentUserLatestVisibility(APIView):


### PR DESCRIPTION
## Issue Number: #850

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

# API Changes

## 1. `GET /api/user/friends/`

**Removed field:** `recent_post`

All other fields remain unchanged.

## 2. `GET /api/user/<username>/unread-posts/` ⭐ New (for bottom sheet)

Returns all notes and responses by the specified user that the requesting user **has not yet read**, sorted by `created_at` descending (newest first).

**Auth:** Required

**No pagination** — returns the full list.

**Calling this endpoint automatically marks all returned posts as read.**

### Response

Array of post objects. Each object is either a `NoteSerializer` or `ResponseSerializer` payload with an additional `type` field.

| Field  | Type | Value |
|--------|------|-------|
| `type` | string | `"Note"` or `"Response"` |
| ...    | ...  | All standard Note/Response fields |

#### Note object example
```json
{
  "type": "Note",
  "id": 30,
  "content": "...",
  "created_at": "2026-03-07T14:22:22Z",
  "current_user_read": false,
  "images": [],
  "visibility": ["friends"],
  "comment_count": 0,
  "current_user_like_id": null,
  "current_user_reaction_id_list": [],
  "like_reaction_user_sample": [],
  "author": "...",
  "author_detail": { ... },
  "is_edited": false,
  "pinned": false,
  "pin_id": null
}
```

#### Response object example

```json

{
  "type": "Response",
  "id": 21,
  "content": "...",
  "created_at": "2025-12-25T23:32:06Z",
  "current_user_read": false,
  "question": { "id": 2, "type": "Question", "content": "..." },
  "visibility": ["friends"],
  "comment_count": 0,
  "current_user_like_id": null,
  "current_user_reaction_id_list": [],
  "like_reaction_user_sample": [],
  "author": "...",
  "author_detail": { ... },
  "is_edited": false,
  "pinned": false,
  "pin_id": null
}