### PR TITLE
feat: support non-hashtag persona/interest input format

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -75,7 +75,12 @@ def parse_hashtags_or_list(data):
         return []
     if isinstance(data, list):
         return data
-    return re.findall(r'#([^\s#]+)', data)
+    # Try hashtag format first
+    tags = re.findall(r'#([^\s#]+)', data)
+    if tags:
+        return tags
+    # Fallback: space-separated strings without #
+    return [t.strip() for t in data.split() if t.strip()]
 
 def get_or_create_normalized_tag(model, raw_tag):
     normalized_input = normalize_tag(raw_tag)

--- a/adoorback/adoorback/settings/development.py
+++ b/adoorback/adoorback/settings/development.py
@@ -31,8 +31,8 @@ DATABASES = {
 
 ALLOWED_HOSTS = ['*']
 
-CORS_ALLOWED_ORIGINS = ['http://localhost:3000']
-CSRF_TRUSTED_ORIGINS = ['http://localhost:3000']
+CORS_ALLOWED_ORIGINS = ['http://localhost:3000', 'http://localhost:3001']
+CSRF_TRUSTED_ORIGINS = ['http://localhost:3000', 'http://localhost:3001']
 CORS_ALLOW_CREDENTIALS = True
 CSRF_COOKIE_HTTPONLY = False 
 CSRF_COOKIE_SAMESITE = 'Lax'


### PR DESCRIPTION
Update parse_hashtags_or_list to handle plain space-separated strings without # prefix. Add localhost:3001 to CORS for local development.

## Issue Number: #859 

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

## Preview Image

## Further comments
