### PR TITLE
(#858) discover tab enable multiple filters

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -1932,24 +1932,15 @@ class DiscoverFeedView(generics.ListAPIView):
             created_at=latest_timestamp
         ).select_related('response', 'response__author', 'response__question', 'note', 'note__author')
 
-        # Filter by type if not 'all'
-        type_param = type_param.lower().rstrip('/')
-        if type_param == 'mutual_friends':
-            queryset = queryset.filter(category='mutual_friends')
-        elif type_param == 'mutual_traits':
-            queryset = queryset.filter(category='mutual_traits')
-        elif type_param == 'anonymous':
-            queryset = queryset.filter(category='anonymous')
-        elif type_param == 'random':
-            queryset = queryset.filter(category='random')
+        # Parse type param — supports single value or comma-separated (e.g. "mutual_friends,mutual_traits")
+        raw_types = [t.strip().lower().rstrip('/') for t in type_param.split(',') if t.strip()]
+        valid_types = {'mutual_friends', 'mutual_traits'}
+        selected_types = [t for t in raw_types if t in valid_types]
 
-        # If 'all', we might want a specific mixed ordering
-        if type_param == 'all':
-            # We can use the order they were added or a custom sort_order field if we add one.
-            # For now, let's just make sure it's consistent.
-            queryset = queryset.order_by('id') # Or some other stable order
-        else:
-            queryset = queryset.order_by('-id')
+        if selected_types:
+            queryset = queryset.filter(category__in=selected_types)
+
+        queryset = queryset.order_by('id')
 
         return queryset
 


### PR DESCRIPTION
## Issue Number: #858

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

# Discover Feed API Changes

## Endpoint

`GET /discover/` (or relevant discover feed endpoint)

---

## `type` Query Parameter

### Valid values

| Value | Description |
|---|---|
| *(omitted)* or `all` | Returns all feed items |
| `mutual_friends` | Returns only mutual friends' posts |
| `mutual_traits` | Returns only mutual traits' posts |
| `mutual_friends,mutual_traits` | Returns posts from both categories combined |

### Removed values

`anonymous` and `random` are **no longer accepted** as `type` values. Items that were previously categorized as anonymous or random are still included when calling with `all` (or no parameter).

---

## Multiple type selection (new)

Pass a comma-separated string to combine categories:

```
GET /discover/?type=mutual_friends,mutual_traits
```

This returns posts from both `mutual_friends` and `mutual_traits`, merged and sorted together (same ordering as `all`).

---

## Ordering

All responses are returned in **newest-first order**, regardless of the `type` parameter.
