### PR TITLE
(#856) enable ping b/w strangers

### DIFF
--- a/adoorback/ping/models.py
+++ b/adoorback/ping/models.py
@@ -36,11 +36,6 @@ class PingRoom(AdoorTimestampedModel, SafeDeleteModel):
     def __str__(self):
         return f"PingRoom between {self.user1} and {self.user2}"
     
-    def clean(self):
-        super().clean()
-        if not self.user1.is_connected(self.user2):
-            raise ValidationError("Users in the message room must be friends.")
-    
     def save(self, *args, **kwargs):
         # if deleting, do not clean
         if self.deleted:

--- a/adoorback/ping/views.py
+++ b/adoorback/ping/views.py
@@ -6,7 +6,7 @@ from rest_framework import generics, exceptions
 from rest_framework.permissions import IsAuthenticated
 
 from adoorback.utils.validators import adoor_exception_handler
-from .models import Ping, PingRoom, get_or_create_ping_room
+from .models import Ping, PingRoom, get_or_create_ping_room, get_ping_room
 from .serializers import PingSerializer, PingRoomSerializer
 
 User = get_user_model()
@@ -54,16 +54,18 @@ class PingList(generics.ListCreateAPIView):
         user = self.request.user
         try:
             connected_user = User.objects.get(id=self.kwargs.get('pk'))
-            if not user.is_connected(connected_user):
-                raise exceptions.PermissionDenied("You are not connected to this user")
         except User.DoesNotExist:
             raise exceptions.NotFound("Connected user not found")
 
-        ping_room = get_or_create_ping_room(connected_user, user)
+        ping_room = get_ping_room(connected_user, user)
+        if not ping_room:
+            self.oldest_unread_page = 1
+            return []
+
         pings = list(ping_room.pings.all())  # to freeze the unread status
 
         oldest_unread = ping_room.pings.filter(receiver=user, is_read=False).order_by('id').first()
-        
+
         if oldest_unread:
             oldest_position = Ping.objects.filter(ping_room=ping_room, id__gte=oldest_unread.id).count()
             pagination_size = getattr(settings, 'REST_FRAMEWORK', {}).get('PAGE_SIZE', 10)
@@ -96,9 +98,6 @@ class PingList(generics.ListCreateAPIView):
         user = self.request.user
         try:
             connected_user = User.objects.get(id=self.kwargs.get('pk'))
-
-            if not user.is_connected(connected_user):
-                raise exceptions.PermissionDenied("You are not connected to this user")
         except User.DoesNotExist:
             raise exceptions.NotFound("Connected user not found")
 


### PR DESCRIPTION
## Issue Number: #856

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

# Ping API Changes

## Summary

Ping (messaging) is no longer restricted to connected (friend) users. Any authenticated user can now send a ping to any other user.

---

## What changed

- **Friend check removed**: The backend no longer validates that two users are connected before allowing ping operations. Previously, both `GET` and `POST` requests returned `403 Permission Denied` if the users were not friends.
- **PingRoom created on first message**: A `PingRoom` is created lazily when the first message (`POST`) is sent. `GET` requests return an empty list if no room exists yet.

---

## Endpoints

### `GET /ping/user/<user_id>/` — List pings with a user

| Before | After |
|---|---|
| `403` if not friends | Returns pings (empty list if no conversation yet) |

- If no `PingRoom` exists yet, returns an empty paginated response with `oldest_unread_page: 1`.
- No other response format changes.

### `POST /ping/user/<user_id>/` — Send a ping

| Before | After |
|---|---|
| `403` if not friends | Creates `PingRoom` on the fly and sends the ping |

- Request/response body unchanged.
- `PingRoom` is automatically created if it doesn't exist.

### `GET /ping/rooms/` — List ping rooms

- No changes. Still returns only rooms that have at least one message.
- Rooms with non-friend users will now appear here once a message has been exchanged.
