### PR TITLE
(#855) add friendship level field to profile API

### DIFF
--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -187,6 +187,7 @@ class UserProfileSerializer(UserMinimalSerializer):
     friend_count = serializers.SerializerMethodField(read_only=True)
     mutual_personas = serializers.SerializerMethodField(read_only=True)
     mutual_interests = serializers.SerializerMethodField(read_only=True)
+    friendship_level = serializers.SerializerMethodField(read_only=True)
 
     def get_is_favorite(self, obj):
         request = self.context.get('request')
@@ -267,6 +268,18 @@ class UserProfileSerializer(UserMinimalSerializer):
                 return ping_room.pings.filter(receiver=user, is_read=False).count()
         return 0
     
+    def get_friendship_level(self, obj):
+        user = self.context.get('request', None).user
+        if user == obj:
+            return None
+        if user.is_connected(obj):
+            return '1st'
+        current_user_connections = set(user.connected_user_ids)
+        obj_connections = set(obj.connected_user_ids)
+        if current_user_connections & obj_connections:
+            return '2nd'
+        return '3rd+'
+
     def get_friend_count(self, obj):
         return Connection.objects.filter(Q(user1=obj) | Q(user2=obj)).count()
 
@@ -280,7 +293,8 @@ class UserProfileSerializer(UserMinimalSerializer):
                                                       'pronouns', 'bio', 'persona', 'user_interests', 'user_personas',
                                                       'unread_ping_count', 'connection_status',
                                                       'friend_count', 'email_verified',
-                                                      'mutual_personas', 'mutual_interests']
+                                                      'mutual_personas', 'mutual_interests',
+                                                      'friendship_level']
 
 
 class FriendListSerializer(UserMinimalSerializer):


### PR DESCRIPTION
## Issue Number: #855

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

# API Change: `friendship_level` field added to User Profile

**Endpoint:** `GET /user/<str:username>/profile/`

## New Field

| Field | Type | Description |
|-------|------|-------------|
| `friendship_level` | `string \| null` | Relationship level between the current user and the profile user |

## Possible Values

| Value | Meaning |
|-------|---------|
| `null` | Viewing own profile |
| `"1st"` | Direct connection (friend or close friend) |
| `"2nd"` | Friend-of-a-friend (connected through a mutual connection) |
| `"3rd+"` | No direct or second-degree connection |

## Example Response (partial)

```json
{
  "username": "john",
  "are_friends": false,
  "connection_status": null,
  "friendship_level": "2nd"
}
```

## Notes

- No request parameter changes — the field is always included in the response.
- `"2nd"` covers all combinations: friend-friend, friend-close_friend, close_friend-close_friend.
