### PR TITLE
(#864) add API for has_posted_note_today

### DIFF
--- a/adoorback/account/tests.py
+++ b/adoorback/account/tests.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.contrib.auth import get_user_model
 from account.models import Connection
 from account.serializers import UserProfileSerializer
-from rest_framework.test import APIRequestFactory
+from rest_framework.test import APIRequestFactory, APIClient
 
 User = get_user_model()
 
@@ -24,3 +24,29 @@ class ProfileCountTests(TestCase):
         data = serializer.data
 
         self.assertEqual(data.get('friend_count'), 1)
+
+
+class CurrentUserNoteStatusTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='test_user',
+            password='password',
+            email='test@example.com',
+            timezone='Asia/Seoul'
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.url = '/api/user/me/note-status/'
+
+    def test_note_status_without_note(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data['has_posted_note_today'])
+
+    def test_note_status_with_note_today(self):
+        from note.models import Note
+        Note.objects.create(author=self.user, content='test note today')
+        
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['has_posted_note_today'])

--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -28,6 +28,7 @@ urlpatterns = [
     path('me/search/', views.CurrentUserFriendSearch.as_view(), name='current-user-friend-search'),
     path('me/all-posts/', views.CurrentUserAllPostList.as_view(), name='current-user-all-post-list'),
     path('me/latest-visibility/', views.CurrentUserLatestVisibility.as_view(), name='current-user-latest-visibility'),
+    path('me/note-status/', views.CurrentUserNoteStatus.as_view(), name='current-user-note-status'),
     path('me/interests/', views.CurrentUserInterestUpdate.as_view(), name='current-user-interest-update'),
     path('me/personas/', views.CurrentUserPersonaUpdate.as_view(), name='current-user-persona-update'),
 

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -810,6 +810,25 @@ class CurrentUserLatestVisibility(APIView):
              return Response({'visibility': latest_response.visibility}, status=200)
 
 
+class CurrentUserNoteStatus(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def get(self, request):
+        user = request.user
+        tz_now = timezone.now().astimezone(ZoneInfo(user.timezone))
+        start_of_today = tz_now.replace(hour=0, minute=0, second=0, microsecond=0)
+        
+        has_posted_note_today = Note.objects.filter(
+            author=user,
+            created_at__gte=start_of_today
+        ).exists()
+        
+        return Response({'has_posted_note_today': has_posted_note_today}, status=200)
+
+
 class CurrentUserDetail(generics.RetrieveUpdateAPIView):
     serializer_class = CurrentUserSerializer
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
## Issue Number: #864

## Self Check List

- [x] Have you double-checked the base branch into which this PR will be merged?
- [x] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

# API Update: Current User Note Status

## New Endpoint
`GET /api/user/me/note-status/`

## Description
This endpoint checks if the currently authenticated user has posted at least one **Note** today (calculated based on the user's local timezone). 

**Frontend Usage:** Use this value to decide whether to show or hide the "post today's TMI" card on the Share tab.
- If `true`: Hide the card.
- If `false`: Show the card.

## Request
- **Method:** `GET`
- **Authentication:** Required (User must be logged in)

## Response
Returns a JSON object indicating the user's note posting status for the current day.

### Success Response (200 OK)
```json
{
  "has_posted_note_today": true
}
```

### Response Fields
| Field | Type | Description |
| :--- | :--- | :--- |
| `has_posted_note_today` | `boolean` | `true` if the user has posted at least one Note today, `false` if they haven't posted any. |