### PR TITLE
feat: add share_type field and update visibility choices

### DIFF
--- a/adoorback/note/migrations/0010_note_share_type.py
+++ b/adoorback/note/migrations/0010_note_share_type.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('note', '0009_alter_note_visibility'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='note',
+            name='share_type',
+            field=models.CharField(
+                choices=[
+                    ('regular', 'Regular'),
+                    ('tmi_of_the_day', 'TMI of the Day'),
+                    ('photo_of_the_day', 'Photo of the Day'),
+                ],
+                default='regular',
+                max_length=20,
+            ),
+        ),
+    ]

--- a/adoorback/note/models.py
+++ b/adoorback/note/models.py
@@ -40,12 +40,23 @@ def note_image_path(instance, filename):
     return f'note_images/{instance.note.author_id}/{instance.note.id}/{unique_id}_{filename}'
 
 
+class ShareType(models.TextChoices):
+    REGULAR = 'regular', 'Regular'
+    TMI_OF_THE_DAY = 'tmi_of_the_day', 'TMI of the Day'
+    PHOTO_OF_THE_DAY = 'photo_of_the_day', 'Photo of the Day'
+
+
 class Note(AdoorModel, SafeDeleteModel):
     author = models.ForeignKey(User, related_name='note_set', on_delete=models.CASCADE)
     visibility = ArrayField(
         models.CharField(max_length=20),
         default=list,
         blank=True
+    )
+    share_type = models.CharField(
+        max_length=20,
+        choices=ShareType.choices,
+        default=ShareType.REGULAR,
     )
 
     note_comments = GenericRelation(Comment)

--- a/adoorback/note/serializers.py
+++ b/adoorback/note/serializers.py
@@ -65,7 +65,8 @@ class VisibilityField(serializers.MultipleChoiceField):
 class NoteSerializer(BaseNoteSerializer):
     current_user_reaction_id_list = serializers.SerializerMethodField(read_only=True)
     like_reaction_user_sample = serializers.SerializerMethodField(read_only=True)
-    visibility = VisibilityField(choices=['friends', 'close_friends', 'public'], required=True)
+    visibility = VisibilityField(choices=['only_me', 'close_friends', 'friends', 'public'], required=True)
+    share_type = serializers.CharField(required=False, default='regular')
 
     def validate_visibility(self, value):
         if len(value) != 1:
@@ -104,7 +105,7 @@ class NoteSerializer(BaseNoteSerializer):
         ]
 
     class Meta(BaseNoteSerializer.Meta):
-        fields = BaseNoteSerializer.Meta.fields + ['current_user_reaction_id_list', 'like_reaction_user_sample', 'visibility']
+        fields = BaseNoteSerializer.Meta.fields + ['current_user_reaction_id_list', 'like_reaction_user_sample', 'visibility', 'share_type']
 
 
 class DefaultFriendNoteSerializer(BaseNoteSerializer):
@@ -115,7 +116,7 @@ class DefaultFriendNoteSerializer(BaseNoteSerializer):
     '''
     like_count = serializers.SerializerMethodField(read_only=True)
     like_user_sample = serializers.SerializerMethodField(read_only=True)
-    visibility = VisibilityField(choices=['friends', 'close_friends', 'public'], required=True)
+    visibility = VisibilityField(choices=['only_me', 'close_friends', 'friends', 'public'], required=True)
 
     def validate_visibility(self, value):
         if len(value) != 1:
@@ -131,4 +132,4 @@ class DefaultFriendNoteSerializer(BaseNoteSerializer):
         return UserMinimalSerializer(recent_users, many=True, context=self.context).data
 
     class Meta(BaseNoteSerializer.Meta):
-        fields = BaseNoteSerializer.Meta.fields + ['like_count', 'like_user_sample', 'visibility']
+        fields = BaseNoteSerializer.Meta.fields + ['like_count', 'like_user_sample', 'visibility', 'share_type']


### PR DESCRIPTION
## Summary
- Add ShareType enum (regular, tmi_of_the_day, photo_of_the_day) to Note model with migration
- Add share_type field to NoteSerializer and DefaultFriendNoteSerializer
- Update visibility choices to include 'only_me' option in both serializers

## Test plan
- [ ] Verify migration applies cleanly
- [ ] Verify posting notes with share_type works (regular, tmi_of_the_day, photo_of_the_day)
- [ ] Verify posting with 'only_me' visibility option is accepted
- [ ] Verify existing notes with old visibility values still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)