### PR TITLE
chore: seed 10 days of selected questions for testing

### DIFF
--- a/adoorback/adoorback/test/seed.py
+++ b/adoorback/adoorback/test/seed.py
@@ -102,8 +102,11 @@ def set_seed(n):
     logging.info(f"{Question.objects.count()} Question(s) created!") \
         if DEBUG else None
 
-    # Select Daily Questions
-    select_daily_questions()
+    # Select Daily Questions for the past 10 days (including today)
+    import datetime
+    today = datetime.date.today()
+    for day_offset in range(10):
+        select_daily_questions(set_date=today - datetime.timedelta(days=day_offset))
 
     # Seed Response (with public visibility for discover testing)
     questions = Question.objects.all()


### PR DESCRIPTION
## Summary
- Select daily questions for the past 10 days (including today) instead of just the current day in seed data
- Provides enough historical question data to test the Questions page navigation from the side menu

## Test plan
- [ ] Run `python manage.py seed` to repopulate the database
- [ ] Open the Questions page from the folded side navigation
- [ ] Verify questions appear for multiple days (up to 10 days back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)