### PR TITLE
fix: SQL syntax error in QuestionList view

### DIFF
--- a/adoorback/qna/views.py
+++ b/adoorback/qna/views.py
@@ -188,8 +188,12 @@ class QuestionList(generics.ListCreateAPIView):
             tz = ZoneInfo("America/Los_Angeles")
         today = timezone.now().astimezone(tz).date()
         daily_questions = list(Question.objects.daily_questions(request.user))  # To match order with DailyQuestionList
-        excluded_ids = tuple(q.id for q in daily_questions)
-        excluded_clause = "AND id NOT IN %s" if excluded_ids else ""
+        excluded_ids = [q.id for q in daily_questions]
+        if excluded_ids:
+            placeholders = ', '.join(['%s'] * len(excluded_ids))
+            excluded_clause = f"AND id NOT IN ({placeholders})"
+        else:
+            excluded_clause = ""
         sql = f"""
             SELECT * FROM qna_question
             WHERE array_length(selected_dates, 1) IS NOT NULL
@@ -198,9 +202,7 @@ class QuestionList(generics.ListCreateAPIView):
             ORDER BY selected_dates[array_upper(selected_dates, 1)] DESC
             LIMIT 14;
         """
-        params = [today]
-        if excluded_ids:
-            params.append(excluded_ids)
+        params = [today] + excluded_ids
         
         queryset = list(Question.objects.raw(sql, params))
         all_questions = daily_questions + queryset


### PR DESCRIPTION
## Summary
- Fixed `ProgrammingError` in `/api/qna/questions/` endpoint
- `objects.raw()` was stringifying a Python tuple as `'(52,1)'` instead of expanding it for the `NOT IN` clause
- Replaced tuple parameter with explicit per-id placeholders (`%s, %s, ...`) so the parameterized query generates valid SQL
- Also populated 10 days of selected questions in the database for testing

## Test plan
- [ ] Open the Questions page from the side navigation
- [ ] Verify questions are grouped by date for multiple past days
- [ ] Verify today's daily questions appear at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)