### PR TITLE
logging

### DIFF
--- a/EXPERIMENT_LOGGING.md
+++ b/EXPERIMENT_LOGGING.md
@@ -1,0 +1,92 @@
+# Experiment API Logging System
+
+## Problem
+
+Existing logs (`error.log`, `info.log`, `debug.log`) are text-based, mixed with Django debug output, and lack experiment context (version, group). Not suitable for behavior analysis across the 4-week Q/W field deployment.
+
+## Solution
+
+A dedicated `experiment.log` file in JSONL format (one JSON object per line), completely separated from dev logs. Every API request is automatically captured via middleware — no view code changes needed.
+
+## Created Files
+
+| File | Purpose |
+|---|---|
+| `adoorback/adoorback/experiment_logging/__init__.py` | Package init |
+| `adoorback/adoorback/experiment_logging/route_map.py` | Maps ~90 URL names to action categories and names |
+| `adoorback/adoorback/experiment_logging/formatters.py` | JSON log formatter |
+| `adoorback/adoorback/experiment_logging/middleware.py` | Core middleware that intercepts all API requests |
+
+## Modified Files
+
+`adoorback/adoorback/settings/base.py`:
+- Added `ExperimentLoggingMiddleware` at the end of `MIDDLEWARE` (after `AuthenticationMiddleware` so `request.user` is available)
+- Added `experiment_json` formatter, `experiment_file` handler, and `experiment` logger to `LOGGING` with `propagate: False` to keep it isolated from dev logs
+
+## Log Format
+
+Each line in `experiment.log`:
+
+```json
+{
+  "timestamp": "2026-04-15T14:23:01.456+09:00",
+  "request_id": "a1b2c3d4e5f6",
+  "duration_ms": 42,
+  "user": {
+    "id": 17,
+    "username": "alice",
+    "current_ver": "version_w",
+    "user_group": "group_w_first",
+    "user_type": "direct"
+  },
+  "request": {
+    "method": "POST",
+    "path": "/api/likes/",
+    "body": {"target_type": "note", "target_id": 42}
+  },
+  "response": {"status_code": 201},
+  "action": {
+    "category": "social_interaction",
+    "name": "like_create",
+    "target_id": 42,
+    "target_type": "note"
+  },
+  "client": {"os": "iOS", "page": "friend_feed"},
+  "api_version": "w"
+}
+```
+
+## Action Categories (11 total)
+
+| Category | Actions |
+|---|---|
+| `content_creation` | note/response/check_in/song create, edit, delete |
+| `social_interaction` | like, comment, reaction, poke, response_request |
+| `relationship_change` | friend_request, connection_update, unfriend, favorite, hidden |
+| `messaging` | ping, ping_request, chat rooms/messages |
+| `discovery_feed` | feed, discover, search, profile views |
+| `content_consumption` | read marking, detail/comments/interactions views |
+| `session_auth` | login, logout, signup, app_session start/end/touch |
+| `subscription` | subscribe, unsubscribe |
+| `moderation` | content_report, user_report, block_recommendation |
+| `profile_management` | profile/interest/persona/chip updates |
+| `notification` | notification list, read, mark_all_read |
+
+## Key Design Decisions
+
+- **Middleware-only approach** — no per-view changes required. Action classification is done via a static URL name-to-action map (`route_map.py`)
+- **PATH_PREFIX_MAP** handles unnamed URLs (chat endpoints) and disambiguates the `response-list` name conflict between `reaction/urls.py` and `qna/urls.py`
+- **Full request body stored** for POST/PUT/PATCH (note content, comments, etc.). Only `password`, `token`, `secret`, `registration_id` are filtered out
+- **Skipped paths**: `/api/health/`, `/api/secret/`, `/api/devices/`, `/static/`, `/media/`
+- **Superuser requests** are logged with `user_type: "admin"` (filterable later)
+- **Daily log rotation** at midnight, consistent with existing log setup
+- **Existing Docker volume mount** (`./adoorback/adoorback/logs:/app/adoorback/adoorback/logs`) already covers the new log file
+
+## Verification
+
+```bash
+# After running the server and making API calls:
+cat logs/experiment.log | jq .
+# or
+cat logs/experiment.log | python -m json.tool
+```

--- a/adoorback/adoorback/experiment_logging/formatters.py
+++ b/adoorback/adoorback/experiment_logging/formatters.py
@@ -1,0 +1,12 @@
+import logging
+
+
+class JSONExperimentFormatter(logging.Formatter):
+    """Formatter that outputs the log message as-is.
+
+    The middleware already produces a JSON string, so this formatter
+    simply passes it through without adding any extra formatting.
+    """
+
+    def format(self, record):
+        return record.getMessage()

--- a/adoorback/adoorback/experiment_logging/middleware.py
+++ b/adoorback/adoorback/experiment_logging/middleware.py
@@ -1,0 +1,200 @@
+import json
+import logging
+import time
+import uuid
+
+from django.urls import resolve, Resolver404
+from user_agents import parse as parse_user_agent
+
+from .route_map import ROUTE_ACTION_MAP, PATH_PREFIX_MAP
+
+logger = logging.getLogger('experiment')
+
+SKIP_PREFIXES = (
+    '/api/health/',
+    '/api/secret/',
+    '/api/devices/',
+    '/static/',
+    '/media/',
+)
+
+SENSITIVE_KEYS = {'password', 'token', 'secret', 'registration_id'}
+
+
+class ExperimentLoggingMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        path = request.path_info
+
+        if self._should_skip(path):
+            return self.get_response(request)
+
+        start = time.monotonic()
+        request_id = uuid.uuid4().hex[:12]
+
+        response = self.get_response(request)
+
+        duration_ms = round((time.monotonic() - start) * 1000, 1)
+
+        try:
+            entry = self._build_entry(request, response, request_id, duration_ms)
+            logger.info(json.dumps(entry, ensure_ascii=False, default=str))
+        except Exception:
+            pass
+
+        return response
+
+    def _should_skip(self, path):
+        return any(path.startswith(p) for p in SKIP_PREFIXES)
+
+    def _build_entry(self, request, response, request_id, duration_ms):
+        user_data = self._extract_user(request)
+        action_data = self._resolve_action(request)
+        body = self._extract_body(request)
+        client = self._extract_client(request)
+        api_version = 'q' if request.path_info.startswith('/api/q/') else 'w'
+
+        # Extract target_id from URL kwargs
+        target_id = None
+        try:
+            resolved = resolve(request.path_info)
+            target_id = resolved.kwargs.get('pk')
+        except Resolver404:
+            pass
+
+        # Also try to get target info from body
+        target_type = None
+        if isinstance(body, dict):
+            if 'target_type' in body:
+                target_type = body.get('target_type')
+            if 'target_id' in body and target_id is None:
+                target_id = body.get('target_id')
+            if 'object_id' in body and target_id is None:
+                target_id = body.get('object_id')
+
+        action = {
+            'category': action_data.get('category', 'uncategorized'),
+            'name': action_data.get('name', 'unknown'),
+        }
+        if target_id is not None:
+            action['target_id'] = target_id
+        if target_type is not None:
+            action['target_type'] = target_type
+
+        entry = {
+            'timestamp': self._now_iso(),
+            'request_id': request_id,
+            'duration_ms': duration_ms,
+            'user': user_data,
+            'request': {
+                'method': request.method,
+                'path': request.path_info,
+                'body': body,
+            },
+            'response': {
+                'status_code': response.status_code,
+            },
+            'action': action,
+            'client': client,
+            'api_version': api_version,
+        }
+        return entry
+
+    def _extract_user(self, request):
+        user = getattr(request, 'user', None)
+        if user is None or not getattr(user, 'is_authenticated', False):
+            return None
+
+        if user.is_superuser:
+            user_type = 'admin'
+        else:
+            user_type = getattr(user, 'user_type', None)
+
+        return {
+            'id': user.id,
+            'username': user.username,
+            'current_ver': getattr(user, 'current_ver', None),
+            'user_group': getattr(user, 'user_group', None),
+            'user_type': user_type,
+        }
+
+    def _resolve_action(self, request):
+        path = request.path_info
+        method = request.method
+        url_name = None
+
+        try:
+            resolved = resolve(path)
+            url_name = resolved.url_name
+        except Resolver404:
+            pass
+
+        # Check PATH_PREFIX_MAP first for conflict resolution and unnamed URLs
+        for entry in PATH_PREFIX_MAP:
+            if not path.startswith(entry['prefix']):
+                continue
+            if entry.get('skip'):
+                return {'category': 'skip', 'name': 'skip'}
+            # If entry specifies a url_name, only match if it matches
+            if 'url_name' in entry and url_name != entry['url_name']:
+                continue
+            return self._resolve_action_entry(entry, method)
+
+        # Then check ROUTE_ACTION_MAP by url_name
+        if url_name and url_name in ROUTE_ACTION_MAP:
+            return self._resolve_action_entry(ROUTE_ACTION_MAP[url_name], method)
+
+        # Fallback
+        path_slug = path.strip('/').replace('/', '_')
+        return {
+            'category': 'uncategorized',
+            'name': f'{method.lower()}_{path_slug}',
+        }
+
+    def _resolve_action_entry(self, entry, method):
+        category = entry.get('category', 'uncategorized')
+        if 'name_by_method' in entry:
+            name = entry['name_by_method'].get(method, entry.get('name', 'unknown'))
+        else:
+            name = entry.get('name', 'unknown')
+        return {'category': category, 'name': name}
+
+    def _extract_body(self, request):
+        if request.method not in ('POST', 'PUT', 'PATCH'):
+            return None
+
+        try:
+            data = request.data
+            if hasattr(data, 'dict'):
+                data = data.dict()
+            else:
+                data = dict(data)
+
+            # Filter sensitive fields
+            for key in list(data.keys()):
+                if key.lower() in SENSITIVE_KEYS:
+                    data[key] = '[FILTERED]'
+
+            return data
+        except Exception:
+            return None
+
+    def _extract_client(self, request):
+        page = request.headers.get('X-Current-Page', None)
+
+        os_name = None
+        ua_str = request.META.get('HTTP_USER_AGENT', '')
+        if ua_str:
+            ua = parse_user_agent(ua_str)
+            os_name = ua.os.family
+
+        return {
+            'os': os_name,
+            'page': page,
+        }
+
+    def _now_iso(self):
+        from django.utils import timezone
+        return timezone.now().isoformat()

--- a/adoorback/adoorback/experiment_logging/route_map.py
+++ b/adoorback/adoorback/experiment_logging/route_map.py
@@ -1,0 +1,333 @@
+# URL name -> action mapping for experiment logging.
+#
+# Each entry maps a Django URL name to an action category and name.
+# For URLs that handle multiple HTTP methods with different semantics,
+# use 'name_by_method' instead of 'name'.
+
+ROUTE_ACTION_MAP = {
+    # ===== Session / Auth =====
+    'login':                            {'category': 'session_auth', 'name': 'login'},
+    'logout':                           {'category': 'session_auth', 'name': 'logout'},
+    'user-email-check':                 {'category': 'session_auth', 'name': 'email_check'},
+    'user-password-check':              {'category': 'session_auth', 'name': 'password_check'},
+    'user-username-check':              {'category': 'session_auth', 'name': 'username_check'},
+    'user-birthdate-check':             {'category': 'session_auth', 'name': 'birthdate_check'},
+    'user-inviter-birthdate-check':     {'category': 'session_auth', 'name': 'inviter_birthdate_check'},
+    'user-signup':                      {'category': 'session_auth', 'name': 'signup'},
+    'user-verify-email':                {'category': 'session_auth', 'name': 'verify_email'},
+    'user-send-reset-password-email':   {'category': 'session_auth', 'name': 'send_reset_password_email'},
+    'user-reset-password':              {'category': 'session_auth', 'name': 'reset_password'},
+    'current-user-reset-password':      {'category': 'session_auth', 'name': 'current_user_reset_password'},
+    'user-password-confirm':            {'category': 'session_auth', 'name': 'password_confirm'},
+    'start_session':                    {'category': 'session_auth', 'name': 'session_start'},
+    'end_session':                      {'category': 'session_auth', 'name': 'session_end'},
+    'touch_session':                    {'category': 'session_auth', 'name': 'session_touch'},
+
+    # ===== Current User / Profile =====
+    'current-user-detail':              {'category': 'profile_management', 'name_by_method': {
+                                            'GET': 'current_user_detail_view',
+                                            'PUT': 'current_user_detail_update',
+                                        }},
+    'current-user-delete':              {'category': 'profile_management', 'name': 'account_delete'},
+    'current-user-profile':             {'category': 'profile_management', 'name_by_method': {
+                                            'GET': 'current_user_profile_view',
+                                            'PUT': 'current_user_profile_update',
+                                        }},
+    'current-user-note-list':           {'category': 'content_consumption', 'name': 'current_user_note_list'},
+    'current-user-response-list':       {'category': 'content_consumption', 'name': 'current_user_response_list'},
+    'received-response-request-list':   {'category': 'content_consumption', 'name': 'received_response_request_list'},
+    'current-user-friend-search':       {'category': 'discovery_feed', 'name': 'current_user_friend_search'},
+    'current-user-all-post-list':       {'category': 'content_consumption', 'name': 'current_user_all_post_list'},
+    'current-user-latest-visibility':   {'category': 'profile_management', 'name_by_method': {
+                                            'GET': 'latest_visibility_view',
+                                            'PUT': 'latest_visibility_update',
+                                        }},
+    'current-user-note-status':         {'category': 'content_consumption', 'name': 'current_user_note_status'},
+    'current-user-interest-update':     {'category': 'profile_management', 'name': 'interest_update'},
+    'current-user-persona-update':      {'category': 'profile_management', 'name': 'persona_update'},
+    'current-user-chips-update':        {'category': 'profile_management', 'name': 'chips_update'},
+    'custom-chip-list-create':          {'category': 'profile_management', 'name_by_method': {
+                                            'GET': 'custom_chip_list',
+                                            'POST': 'custom_chip_create',
+                                        }},
+    'chip-categories':                  {'category': 'profile_management', 'name': 'chip_categories_view'},
+
+    # ===== Interest / Persona Search & Recommendation =====
+    'interest-search':                  {'category': 'discovery_feed', 'name': 'interest_search'},
+    'persona-search':                   {'category': 'discovery_feed', 'name': 'persona_search'},
+    'interest-recommendation':          {'category': 'discovery_feed', 'name': 'interest_recommendation'},
+    'persona-recommendation':           {'category': 'discovery_feed', 'name': 'persona_recommendation'},
+
+    # ===== User Profile (other users) =====
+    'user-search':                      {'category': 'discovery_feed', 'name': 'user_search'},
+    'user-detail':                      {'category': 'discovery_feed', 'name': 'user_profile_view'},
+    'user-note-list':                   {'category': 'content_consumption', 'name': 'user_note_list'},
+    'user-response-list':               {'category': 'content_consumption', 'name': 'user_response_list'},
+    'friend-friend-list':               {'category': 'discovery_feed', 'name': 'friend_friend_list'},
+    'user-all-post-list':               {'category': 'content_consumption', 'name': 'user_all_post_list'},
+    'user-unread-post-list':            {'category': 'content_consumption', 'name': 'user_unread_post_list'},
+    'user-mark-all-notes-as-read':      {'category': 'content_consumption', 'name': 'mark_all_notes_read'},
+    'user-mark-all-responses-as-read':  {'category': 'content_consumption', 'name': 'mark_all_responses_read'},
+
+    # ===== Friends =====
+    'friend-list':                      {'category': 'relationship_change', 'name_by_method': {
+                                            'GET': 'friend_list_view',
+                                            'POST': 'friend_request_send',
+                                        }},
+    'friend-update-list':               {'category': 'discovery_feed', 'name': 'friend_update_list'},
+    'current-user-friends-update':      {'category': 'relationship_change', 'name': 'friend_list_update'},
+    'user-favorite-add':                {'category': 'relationship_change', 'name': 'favorite_add'},
+    'user-favorite-destroy':            {'category': 'relationship_change', 'name': 'favorite_remove'},
+    'user-hidden-add':                  {'category': 'relationship_change', 'name': 'hidden_add'},
+    'user-hidden-destroy':              {'category': 'relationship_change', 'name': 'hidden_remove'},
+    'connection-choice-update':         {'category': 'relationship_change', 'name': 'connection_update'},
+    'user-friend-destroy':              {'category': 'relationship_change', 'name': 'unfriend'},
+
+    # ===== Feed =====
+    'friend-feed':                      {'category': 'discovery_feed', 'name': 'friend_feed_view'},
+    'full-friend-feed':                 {'category': 'discovery_feed', 'name': 'full_friend_feed_view'},
+    'discover-feed':                    {'category': 'discovery_feed', 'name': 'discover_feed_view'},
+
+    # ===== Friend Requests =====
+    'user-friend-request-list':         {'category': 'relationship_change', 'name_by_method': {
+                                            'GET': 'friend_request_list',
+                                            'POST': 'friend_request_send',
+                                        }},
+    'user-sent-friend-request-list':    {'category': 'relationship_change', 'name': 'sent_friend_request_list'},
+    'user-friend-request-destroy':      {'category': 'relationship_change', 'name': 'friend_request_cancel'},
+    'user-friend-request-update':       {'category': 'relationship_change', 'name': 'friend_request_respond'},
+
+    # ===== Friend Recommendations =====
+    'user-recommended-friends-list':    {'category': 'discovery_feed', 'name': 'recommended_friends_list'},
+    'block-rec-create':                 {'category': 'moderation', 'name': 'block_recommendation'},
+
+    # ===== Subscriptions =====
+    'subscribe-user-content':           {'category': 'subscription', 'name': 'subscribe'},
+    'unsubscribe-user-content':         {'category': 'subscription', 'name': 'unsubscribe'},
+
+    # ===== TMI =====
+    'tmi-placeholder':                  {'category': 'content_consumption', 'name': 'tmi_placeholder'},
+
+    # ===== QnA =====
+    # NOTE: 'response-list' name is shared with reaction/urls.py. Disambiguated by PATH_PREFIX_MAP.
+    'response-detail':                  {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'response_detail_view',
+                                            'PUT': 'response_edit',
+                                            'PATCH': 'response_edit',
+                                            'DELETE': 'response_delete',
+                                        }},
+    'response-comments':                {'category': 'content_consumption', 'name': 'response_comments_view'},
+    'response-interaction-user-list':   {'category': 'content_consumption', 'name': 'response_interactions_view'},
+    'response-read':                    {'category': 'content_consumption', 'name': 'response_read'},
+    'daily-question-list':              {'category': 'content_consumption', 'name': 'daily_question_list'},
+    'question-list':                    {'category': 'content_consumption', 'name': 'question_list'},
+    'question-detail':                  {'category': 'content_consumption', 'name': 'question_detail_view'},
+    'response-request-create':          {'category': 'social_interaction', 'name': 'response_request_create'},
+
+    # ===== Notes =====
+    'note-list':                        {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'note_list',
+                                            'POST': 'note_create',
+                                        }},
+    'note-detail':                      {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'note_detail_view',
+                                            'PUT': 'note_edit',
+                                            'PATCH': 'note_edit',
+                                            'DELETE': 'note_delete',
+                                        }},
+    'note-comments':                    {'category': 'content_consumption', 'name': 'note_comments_view'},
+    'note-interaction-user-list':       {'category': 'content_consumption', 'name': 'note_interactions_view'},
+    'note-read':                        {'category': 'content_consumption', 'name': 'note_read'},
+
+    # ===== Notices =====
+    'notice-list':                      {'category': 'content_consumption', 'name': 'notice_list'},
+    'notice-detail':                    {'category': 'content_consumption', 'name': 'notice_detail_view'},
+    'notice-comments':                  {'category': 'content_consumption', 'name': 'notice_comments_view'},
+    'notice-interaction-user-list':     {'category': 'content_consumption', 'name': 'notice_interactions_view'},
+    'user-mark-all-notices-as-read':    {'category': 'content_consumption', 'name': 'mark_all_notices_read'},
+
+    # ===== Check-In =====
+    'current-check-in':                 {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'check_in_view',
+                                            'POST': 'check_in_create',
+                                        }},
+    'check-in-detail':                  {'category': 'content_consumption', 'name': 'check_in_detail_view'},
+    'check-in-read':                    {'category': 'content_consumption', 'name': 'check_in_read'},
+    'current-user-latest-check-in-visibility': {'category': 'profile_management', 'name_by_method': {
+                                            'GET': 'check_in_visibility_view',
+                                            'PUT': 'check_in_visibility_update',
+                                        }},
+    'latest-check-in':                  {'category': 'content_consumption', 'name': 'latest_check_in_view'},
+    'current-song':                     {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'song_view',
+                                            'POST': 'song_create',
+                                        }},
+    'my-song-detail':                   {'category': 'content_consumption', 'name': 'song_detail_view'},
+    'check-in-react':                   {'category': 'social_interaction', 'name': 'check_in_reaction_toggle'},
+    'check-in-reactions':               {'category': 'content_consumption', 'name': 'check_in_reactions_view'},
+    'poke-create':                      {'category': 'social_interaction', 'name': 'poke_create'},
+    'poke-sent':                        {'category': 'social_interaction', 'name': 'poke_sent_list'},
+    'poke-delete':                      {'category': 'social_interaction', 'name': 'poke_delete'},
+
+    # ===== Comments =====
+    'comment-create':                   {'category': 'social_interaction', 'name': 'comment_create'},
+    'comment-detail':                   {'category': 'social_interaction', 'name_by_method': {
+                                            'GET': 'comment_detail_view',
+                                            'PUT': 'comment_edit',
+                                            'PATCH': 'comment_edit',
+                                            'DELETE': 'comment_delete',
+                                        }},
+    'comment-like-user-list':           {'category': 'content_consumption', 'name': 'comment_like_user_list'},
+
+    # ===== Likes =====
+    'like-list':                        {'category': 'social_interaction', 'name_by_method': {
+                                            'GET': 'like_list',
+                                            'POST': 'like_create',
+                                        }},
+    'like-destroy':                     {'category': 'social_interaction', 'name': 'like_delete'},
+
+    # ===== Reactions (URL name 'response-list' conflicts with qna) =====
+    # Handled via PATH_PREFIX_MAP below
+    'reaction-destroy':                 {'category': 'social_interaction', 'name': 'reaction_delete'},
+
+    # ===== Ping (messaging) =====
+    'ping-room-list':                   {'category': 'messaging', 'name': 'ping_room_list'},
+    'ping_list':                        {'category': 'messaging', 'name': 'ping_list'},
+    'ping-request-create':              {'category': 'messaging', 'name': 'ping_request_create'},
+    'ping-request-sent-list':           {'category': 'messaging', 'name': 'ping_request_sent_list'},
+    'ping-request-update':              {'category': 'messaging', 'name': 'ping_request_respond'},
+
+    # ===== Chat =====
+    # Most chat URLs have no name; handled via PATH_PREFIX_MAP
+    'message-like-list':                {'category': 'messaging', 'name': 'message_like_list'},
+
+    # ===== Notifications =====
+    'notification-list':                {'category': 'notification', 'name': 'notification_list'},
+    'friend-request-noti-list':         {'category': 'notification', 'name': 'friend_request_noti_list'},
+    'response-request-noti-list':       {'category': 'notification', 'name': 'response_request_noti_list'},
+    'notification-read':                {'category': 'notification', 'name': 'notification_read'},
+    'mark-all-notifications-read':      {'category': 'notification', 'name': 'mark_all_notifications_read'},
+
+    # ===== Content/User Reports =====
+    'content-report-list':              {'category': 'moderation', 'name_by_method': {
+                                            'GET': 'content_report_list',
+                                            'POST': 'content_report_create',
+                                        }},
+    'user-report-list':                 {'category': 'moderation', 'name_by_method': {
+                                            'GET': 'user_report_list',
+                                            'POST': 'user_report_create',
+                                        }},
+
+    # ===== Playlist =====
+    'playlist-feed':                    {'category': 'discovery_feed', 'name': 'playlist_feed_view'},
+
+    # ===== Tracking =====
+    'tracking-dashboard':               {'category': 'other', 'name': 'tracking_dashboard'},
+
+    # ===== Version Q Endpoints =====
+    'q-current-user-detail':            {'category': 'profile_management', 'name_by_method': {
+                                            'GET': 'current_user_detail_view',
+                                            'PUT': 'current_user_detail_update',
+                                        }},
+    'q-current-user-note-list':         {'category': 'content_consumption', 'name': 'current_user_note_list'},
+    'q-current-user-all-post-list':     {'category': 'content_consumption', 'name': 'current_user_all_post_list'},
+    'q-user-detail':                    {'category': 'discovery_feed', 'name': 'user_profile_view'},
+    'q-user-note-list':                 {'category': 'content_consumption', 'name': 'user_note_list'},
+    'q-user-all-post-list':             {'category': 'content_consumption', 'name': 'user_all_post_list'},
+    'q-friend-feed':                    {'category': 'discovery_feed', 'name': 'friend_feed_view'},
+    'q-note-create':                    {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'note_list',
+                                            'POST': 'note_create',
+                                        }},
+    'q-note-detail':                    {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'note_detail_view',
+                                            'PUT': 'note_edit',
+                                            'PATCH': 'note_edit',
+                                            'DELETE': 'note_delete',
+                                        }},
+    'q-response-create':                {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'response_list',
+                                            'POST': 'response_create',
+                                        }},
+    'q-response-detail':                {'category': 'content_creation', 'name_by_method': {
+                                            'GET': 'response_detail_view',
+                                            'PUT': 'response_edit',
+                                            'PATCH': 'response_edit',
+                                            'DELETE': 'response_delete',
+                                        }},
+}
+
+
+# Path-prefix based fallback for URLs without names or with conflicting names.
+# Checked in order; first match wins.
+# 'name_by_method' is supported here too.
+PATH_PREFIX_MAP = [
+    # Disambiguate 'response-list' conflict: reaction vs qna
+    {
+        'prefix': '/api/reactions/',
+        'category': 'social_interaction',
+        'name_by_method': {
+            'GET': 'reaction_list',
+            'POST': 'reaction_create',
+        },
+    },
+    {
+        'prefix': '/api/qna/responses/',
+        'url_name': 'response-list',
+        'category': 'content_creation',
+        'name_by_method': {
+            'GET': 'response_list',
+            'POST': 'response_create',
+        },
+    },
+
+    # Chat URLs (most have no name)
+    {
+        'prefix': '/api/chat/rooms/search/',
+        'category': 'messaging',
+        'name': 'chat_message_search',
+    },
+    {
+        'prefix': '/api/chat/rooms/one_on_one/',
+        'category': 'messaging',
+        'name': 'one_on_one_chat_room_view',
+    },
+    {
+        'prefix': '/api/chat/rooms/friend/',
+        'category': 'messaging',
+        'name': 'chat_room_friend_list',
+    },
+    {
+        'prefix': '/api/chat/rooms/',
+        'category': 'messaging',
+        'name_by_method': {
+            'GET': 'chat_room_list',
+            'POST': 'chat_room_create',
+            'PUT': 'chat_room_update',
+            'DELETE': 'chat_room_delete',
+        },
+    },
+    {
+        'prefix': '/api/chat/messages/likes/',
+        'category': 'messaging',
+        'name': 'message_like_list',
+    },
+    {
+        'prefix': '/api/chat/',
+        'category': 'messaging',
+        'name': 'chat_messages_list',
+    },
+
+    # Translate (no URL name)
+    {
+        'prefix': '/api/translate/',
+        'category': 'other',
+        'name': 'translate',
+    },
+
+    # FCM devices (skip from experiment logging)
+    {
+        'prefix': '/api/devices/',
+        'skip': True,
+    },
+]

--- a/adoorback/adoorback/settings/base.py
+++ b/adoorback/adoorback/settings/base.py
@@ -147,6 +147,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'adoorback.experiment_logging.middleware.ExperimentLoggingMiddleware',
 ]
 
 ROOT_URLCONF = 'adoorback.urls'
@@ -291,6 +292,9 @@ LOGGING = {
             'datefmt': '%Y-%m-%d %H:%M:%S',
             'class': 'adoorback.safe_formatter.SafeFormatter',
         },
+        'experiment_json': {
+            '()': 'adoorback.experiment_logging.formatters.JSONExperimentFormatter',
+        },
     },
     'filters': {
         'add_user_info': {
@@ -324,6 +328,14 @@ LOGGING = {
             'interval': 1,
             'formatter': 'verbose',
         },
+        'experiment_file': {
+            'level': 'INFO',
+            'class': 'logging.handlers.TimedRotatingFileHandler',
+            'filename': os.path.join(LOG_DIR, 'experiment.log'),
+            'when': 'midnight',
+            'interval': 1,
+            'formatter': 'experiment_json',
+        },
     },
     'loggers': {
         'django': {
@@ -344,6 +356,11 @@ LOGGING = {
         'adoorback': {
             'handlers': ['error_file', 'info_file', 'debug_file'],
             'level': 'DEBUG',
+            'propagate': False,
+        },
+        'experiment': {
+            'handlers': ['experiment_file'],
+            'level': 'INFO',
             'propagate': False,
         },
     },


### PR DESCRIPTION
# Experiment API Logging System

## Problem

Existing logs (`error.log`, `info.log`, `debug.log`) are text-based, mixed with Django debug output, and lack experiment context (version, group). Not suitable for behavior analysis across the 4-week Q/W field deployment.

## Solution

A dedicated `experiment.log` file in JSONL format (one JSON object per line), completely separated from dev logs. Every API request is automatically captured via middleware — no view code changes needed.

## Created Files

| File | Purpose |
|---|---|
| `adoorback/adoorback/experiment_logging/__init__.py` | Package init |
| `adoorback/adoorback/experiment_logging/route_map.py` | Maps ~90 URL names to action categories and names |
| `adoorback/adoorback/experiment_logging/formatters.py` | JSON log formatter |
| `adoorback/adoorback/experiment_logging/middleware.py` | Core middleware that intercepts all API requests |

## Modified Files

`adoorback/adoorback/settings/base.py`:
- Added `ExperimentLoggingMiddleware` at the end of `MIDDLEWARE` (after `AuthenticationMiddleware` so `request.user` is available)
- Added `experiment_json` formatter, `experiment_file` handler, and `experiment` logger to `LOGGING` with `propagate: False` to keep it isolated from dev logs

## Log Format

Each line in `experiment.log`:

```json
{
  "timestamp": "2026-04-15T14:23:01.456+09:00",
  "request_id": "a1b2c3d4e5f6",
  "duration_ms": 42,
  "user": {
    "id": 17,
    "username": "alice",
    "current_ver": "version_w",
    "user_group": "group_w_first",
    "user_type": "direct"
  },
  "request": {
    "method": "POST",
    "path": "/api/likes/",
    "body": {"target_type": "note", "target_id": 42}
  },
  "response": {"status_code": 201},
  "action": {
    "category": "social_interaction",
    "name": "like_create",
    "target_id": 42,
    "target_type": "note"
  },
  "client": {"os": "iOS", "page": "friend_feed"},
  "api_version": "w"
}
```

## Action Categories (11 total)

| Category | Actions |
|---|---|
| `content_creation` | note/response/check_in/song create, edit, delete |
| `social_interaction` | like, comment, reaction, poke, response_request |
| `relationship_change` | friend_request, connection_update, unfriend, favorite, hidden |
| `messaging` | ping, ping_request, chat rooms/messages |
| `discovery_feed` | feed, discover, search, profile views |
| `content_consumption` | read marking, detail/comments/interactions views |
| `session_auth` | login, logout, signup, app_session start/end/touch |
| `subscription` | subscribe, unsubscribe |
| `moderation` | content_report, user_report, block_recommendation |
| `profile_management` | profile/interest/persona/chip updates |
| `notification` | notification list, read, mark_all_read |

## Key Design Decisions

- **Middleware-only approach** — no per-view changes required. Action classification is done via a static URL name-to-action map (`route_map.py`)
- **PATH_PREFIX_MAP** handles unnamed URLs (chat endpoints) and disambiguates the `response-list` name conflict between `reaction/urls.py` and `qna/urls.py`
- **Full request body stored** for POST/PUT/PATCH (note content, comments, etc.). Only `password`, `token`, `secret`, `registration_id` are filtered out
- **Skipped paths**: `/api/health/`, `/api/secret/`, `/api/devices/`, `/static/`, `/media/`
- **Superuser requests** are logged with `user_type: "admin"` (filterable later)
- **Daily log rotation** at midnight, consistent with existing log setup
- **Existing Docker volume mount** (`./adoorback/adoorback/logs:/app/adoorback/adoorback/logs`) already covers the new log file

## Verification

```bash
# After running the server and making API calls:
cat logs/experiment.log | jq .
# or
cat logs/experiment.log | python -m json.tool
```
