### PR TITLE
revert #839

### DIFF
--- a/adoorback/check_in/serializers.py
+++ b/adoorback/check_in/serializers.py
@@ -74,7 +74,7 @@ class MyCheckInSerializer(CheckInBaseSerializer):
         model = CheckIn
         fields = CheckInBaseSerializer.Meta.fields
         extra_kwargs = {
-            'visibility': {'required': False},
+            'visibility': {'required': True},
             'mood': {'required': False},
             'battery_updated_at': {'read_only': True},
             'mood_updated_at': {'read_only': True},

--- a/adoorback/check_in/views.py
+++ b/adoorback/check_in/views.py
@@ -33,21 +33,6 @@ class CurrentCheckIn(generics.ListCreateAPIView):
     def perform_create(self, serializer):
         current_user = self.request.user
 
-        # Inherit visibility settings from last check-in if not provided
-        if not serializer.validated_data.get('visibility'):
-            last_check_in = CheckIn.objects.filter(user=current_user).order_by('-created_at').first()
-            if last_check_in:
-                serializer.validated_data['visibility'] = last_check_in.visibility
-            else:
-                serializer.validated_data['visibility'] = ['public']
-
-        # Inherit per-component visibility from last check-in if not provided
-        last_check_in = CheckIn.objects.filter(user=current_user).order_by('-created_at').first()
-        if last_check_in:
-            for field in ['battery_visibility', 'mood_visibility', 'song_visibility', 'thought_visibility']:
-                if field not in serializer.validated_data:
-                    serializer.validated_data[field] = getattr(last_check_in, field)
-
         serializer.save(user=current_user, is_active=True)
 
         # deactivate previous check-in


### PR DESCRIPTION
# Remove Default Visibility Fallback in POST Check-In API

## Changes

- **`check_in/serializers.py`**: Changed `visibility` field from `required: False` to `required: True` in `MyCheckInSerializer`.
- **`check_in/views.py`**: Removed fallback logic in `CurrentCheckIn.perform_create` that inherited visibility from the last check-in or defaulted to `['public']`.

## Behavior

- **Before**: If `visibility` was omitted from the request, the API would silently inherit the previous check-in's visibility or default to `['public']`.
- **After**: If `visibility` is omitted, the API returns a `400` error with `"This field is required."`.
