### PR TITLE
Feat/issue 900

### DIFF
--- a/adoorback/account/models.py
+++ b/adoorback/account/models.py
@@ -890,6 +890,11 @@ def connection_removed(instance, **kwargs):
 
     # 3. No-op: chat rooms use FK pairs, no deactivation needed on unfriend
 
+    # 4. Remove all subscriptions between the two users
+    Subscription.objects.filter(
+        Q(subscriber=user1, subscribed_to=user2) | Q(subscriber=user2, subscribed_to=user1)
+    ).delete()
+
 
 @transaction.atomic
 @receiver(post_save, sender=FriendRequest)
@@ -945,6 +950,19 @@ def create_connection_noti(created, instance, **kwargs):
         # create chat room for new friends
         from chat.models import get_or_create_chat_room
         get_or_create_chat_room(requester, requestee)
+
+        # auto-subscribe close friends to check-in updates (version_w only)
+        if requester.current_ver == 'version_w':
+            from adoorback.utils.content_types import get_check_in_type
+            check_in_ct = get_check_in_type()
+            if instance.requester_choice == 'close_friend':
+                Subscription.objects.create(
+                    subscriber=requester, subscribed_to=requestee, content_type=check_in_ct
+                )
+            if instance.requestee_choice == 'close_friend':
+                Subscription.objects.create(
+                    subscriber=requestee, subscribed_to=requester, content_type=check_in_ct
+                )
 
     # make friend request notification invisible once requestee has responded
     instance.friend_request_targetted_notis.filter(user=requestee,

--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -289,13 +289,24 @@ class UserProfileSerializer(UserMinimalSerializer):
     mutual_personas = serializers.SerializerMethodField(read_only=True)
     mutual_interests = serializers.SerializerMethodField(read_only=True)
     friendship_level = serializers.SerializerMethodField(read_only=True)
+    is_check_in_subscribed = serializers.SerializerMethodField(read_only=True)
+
+    def get_is_check_in_subscribed(self, obj):
+        request = self.context.get('request')
+        if request and request.user.is_authenticated and request.user.current_ver == 'version_w':
+            from adoorback.utils.content_types import get_check_in_type
+            from account.models import Subscription
+            return Subscription.objects.filter(
+                subscriber=request.user, subscribed_to=obj, content_type=get_check_in_type()
+            ).exists()
+        return False
 
     def get_is_favorite(self, obj):
         request = self.context.get('request')
         if request and request.user.is_authenticated:
             return obj in request.user.favorites.all()
         return False
-    
+
     def get_check_in(self, obj):
         user = self.context.get('request', None).user
         check_in = obj.check_in_set.filter(is_active=True).first()
@@ -419,7 +430,7 @@ class UserProfileSerializer(UserMinimalSerializer):
                                                       'unread_chat_count', 'unread_message_cnt', 'connection_status',
                                                       'friend_count', 'email_verified',
                                                       'mutual_personas', 'mutual_interests',
-                                                      'friendship_level']
+                                                      'friendship_level', 'is_check_in_subscribed']
 
 
 class FriendListSerializer(UserMinimalSerializer):
@@ -442,6 +453,10 @@ class FriendListSerializer(UserMinimalSerializer):
     song_visibility = serializers.SerializerMethodField(read_only=True)
     thought_visibility = serializers.SerializerMethodField(read_only=True)
     sent_pokes = serializers.SerializerMethodField(read_only=True)
+    is_check_in_subscribed = serializers.SerializerMethodField(read_only=True)
+
+    def get_is_check_in_subscribed(self, obj):
+        return obj.id in self.context.get('check_in_subscription_ids', set())
 
     def get_sent_pokes(self, obj):
         return self.context.get('pokes_by_receiver', {}).get(obj.id, {})
@@ -587,7 +602,7 @@ class FriendListSerializer(UserMinimalSerializer):
                                                       'bio', 'check_in_id', 'track_id', 'thought',
                                                       'unread_chat_count', 'social_battery', 'mood',
                                                       'battery_visibility', 'mood_visibility', 'song_visibility', 'thought_visibility',
-                                                      'sent_pokes']
+                                                      'sent_pokes', 'is_check_in_subscribed']
 
 
 class FriendFriendListSerializer(UserMinimalSerializer):

--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -92,6 +92,10 @@ urlpatterns = [
     path('friends/subscribe/', views.SubscribeUserContent.as_view(), name='subscribe-user-content'),
     path('friends/<int:pk>/subscribe/', views.UnsubscribeUserContent.as_view(), name='unsubscribe-user-content'),
 
+    # Check-in subscribe (version_w only)
+    path('friends/check-in-subscribe/', views.CheckInSubscribeAdd.as_view(), name='check-in-subscribe-add'),
+    path('friends/<int:pk>/check-in-subscribe/', views.CheckInSubscribeDestroy.as_view(), name='check-in-subscribe-destroy'),
+
     # TMI Placeholder
     path('tmi-placeholder/', views.TmiPlaceholder.as_view(), name='tmi-placeholder'),
 

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -1480,6 +1480,17 @@ class FriendList(generics.ListAPIView):
             bucket.setdefault(p['receiver_id'], {})[p['component_type']] = p['id']
         ctx['pokes_by_receiver'] = bucket
 
+        # 11. Check-in subscriptions (version_w only)
+        if user.current_ver == 'version_w':
+            from adoorback.utils.content_types import get_check_in_type
+            ctx['check_in_subscription_ids'] = set(
+                Subscription.objects.filter(
+                    subscriber=user, content_type=get_check_in_type()
+                ).values_list('subscribed_to_id', flat=True)
+            )
+        else:
+            ctx['check_in_subscription_ids'] = set()
+
 
 class FriendListUpdate(generics.UpdateAPIView):
     serializer_class = UserFriendsUpdateSerializer
@@ -2015,6 +2026,64 @@ class UnsubscribeUserContent(generics.DestroyAPIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+class CheckInSubscribeAdd(generics.CreateAPIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def create(self, request, *args, **kwargs):
+        if request.user.current_ver != 'version_w':
+            return Response({'error': 'This feature is only available in version W.'},
+                            status=status.HTTP_403_FORBIDDEN)
+
+        friend_id = request.data.get('friend_id')
+        if not friend_id:
+            return Response({'error': 'Friend ID must be provided.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            friend_id = int(friend_id)
+        except ValueError:
+            return Response({'error': 'Invalid Friend ID.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        user = request.user
+        friend = get_object_or_404(User, id=friend_id)
+
+        if not user.is_connected(friend):
+            return Response({'error': 'User is not your friend.'}, status=status.HTTP_400_BAD_REQUEST)
+
+        from adoorback.utils.content_types import get_check_in_type
+        check_in_ct = get_check_in_type()
+        if Subscription.objects.filter(subscriber=user, subscribed_to=friend, content_type=check_in_ct).exists():
+            return Response({'error': 'Already subscribed to this friend\'s check-in.'},
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        Subscription.objects.create(subscriber=user, subscribed_to=friend, content_type=check_in_ct)
+        return Response({'message': 'Subscribed to check-in successfully.'}, status=status.HTTP_201_CREATED)
+
+
+class CheckInSubscribeDestroy(generics.DestroyAPIView):
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def destroy(self, request, *args, **kwargs):
+        if request.user.current_ver != 'version_w':
+            return Response({'error': 'This feature is only available in version W.'},
+                            status=status.HTTP_403_FORBIDDEN)
+
+        friend_id = kwargs.get('pk')
+        friend = get_object_or_404(User, id=friend_id)
+        from adoorback.utils.content_types import get_check_in_type
+        check_in_ct = get_check_in_type()
+        subscription = get_object_or_404(
+            Subscription, subscriber=request.user, subscribed_to=friend, content_type=check_in_ct
+        )
+        subscription.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
 class FriendFeed(generics.ListAPIView):
     permission_classes = [IsAuthenticated]
 
@@ -2039,6 +2108,7 @@ class FriendFeed(generics.ListAPIView):
         return page
 
     def list(self, request, *args, **kwargs):
+        user = request.user
         queryset = self.get_queryset()
 
         # freeze notes before marking them as read
@@ -2050,6 +2120,17 @@ class FriendFeed(generics.ListAPIView):
             serialized_data = NoteSerializer(page, many=True, context=self.get_serializer_context()).data
         else:
             serialized_data = NoteSerializer(notes_before_update, many=True, context=self.get_serializer_context()).data
+
+        # inject is_check_in_subscribed into author_detail (version_w only)
+        if user.current_ver == 'version_w':
+            from adoorback.utils.content_types import get_check_in_type
+            check_in_sub_ids = set(Subscription.objects.filter(
+                subscriber=user, content_type=get_check_in_type()
+            ).values_list('subscribed_to_id', flat=True))
+            source_items = page if page is not None else notes_before_update
+            for item, serialized in zip(source_items, serialized_data):
+                if 'author_detail' in serialized and serialized['author_detail']:
+                    serialized['author_detail']['is_check_in_subscribed'] = item.author_id in check_in_sub_ids
 
         # mark all notes as read
         unread_note_ids = queryset.exclude(readers=request.user).values_list("id", flat=True)
@@ -2101,13 +2182,21 @@ class FullFriendFeed(generics.ListAPIView):
         page = self.paginate_queryset(frozen_items)
         objects_to_serialize = page if page is not None else frozen_items
 
+        # prefetch check-in subscriptions (version_w only)
+        check_in_sub_ids = set()
+        if user.current_ver == 'version_w':
+            from adoorback.utils.content_types import get_check_in_type
+            check_in_sub_ids = set(Subscription.objects.filter(
+                subscriber=user, content_type=get_check_in_type()
+            ).values_list('subscribed_to_id', flat=True))
+
         serialized_data = []
         for obj in objects_to_serialize:
             if isinstance(obj, Note):
                 serialized = NoteSerializer(obj, context=self.get_serializer_context()).data
             elif isinstance(obj, _Response):
                 serialized = ResponseSerializer(obj, context=self.get_serializer_context()).data
-            # Add connection_status to author_detail for close friend indicator
+            # Add connection_status and is_check_in_subscribed to author_detail
             if 'author_detail' in serialized and serialized['author_detail']:
                 author = obj.author
                 if author == user:
@@ -2118,6 +2207,8 @@ class FullFriendFeed(generics.ListAPIView):
                     serialized['author_detail']['connection_status'] = 'friend'
                 else:
                     serialized['author_detail']['connection_status'] = None
+                if user.current_ver == 'version_w':
+                    serialized['author_detail']['is_check_in_subscribed'] = obj.author_id in check_in_sub_ids
             serialized_data.append(serialized)
 
         # mark all notes as read

--- a/adoorback/adoorback/utils/content_types.py
+++ b/adoorback/adoorback/utils/content_types.py
@@ -57,6 +57,11 @@ def get_message_type():
     return ContentType.objects.get_for_model(Message)
 
 
+def get_check_in_type():
+    from check_in.models import CheckIn
+    return ContentType.objects.get_for_model(CheckIn)
+
+
 def get_generic_relation_type(model):
     model = model.capitalize()
     if model == 'Comment':
@@ -69,5 +74,7 @@ def get_generic_relation_type(model):
         return get_note_type()
     elif model == 'Message':
         return get_message_type()
+    elif model in ('Check_in', 'Checkin'):
+        return get_check_in_type()
     else:
         return None

--- a/adoorback/chat/migrations/0002_cleanup_old_apps.py
+++ b/adoorback/chat/migrations/0002_cleanup_old_apps.py
@@ -10,21 +10,30 @@ def cleanup_old_apps(apps, schema_editor):
     connection = schema_editor.connection
     cursor = connection.cursor()
 
+    def table_exists(table_name):
+        cursor.execute(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = %s)",
+            [table_name],
+        )
+        return cursor.fetchone()[0]
+
     # 1. Clean up notifications referencing old ping content types
-    cursor.execute("""
-        DELETE FROM notification_notificationactor
-        WHERE notification_id IN (
-            SELECT n.id FROM notification_notification n
-            JOIN django_content_type ct ON n.target_type_id = ct.id
-            WHERE ct.app_label = 'ping'
-        )
-    """)
-    cursor.execute("""
-        DELETE FROM notification_notification
-        WHERE target_type_id IN (
-            SELECT id FROM django_content_type WHERE app_label = 'ping'
-        )
-    """)
+    if table_exists('notification_notificationactor'):
+        cursor.execute("""
+            DELETE FROM notification_notificationactor
+            WHERE notification_id IN (
+                SELECT n.id FROM notification_notification n
+                JOIN django_content_type ct ON n.target_type_id = ct.id
+                WHERE ct.app_label = 'ping'
+            )
+        """)
+    if table_exists('notification_notification'):
+        cursor.execute("""
+            DELETE FROM notification_notification
+            WHERE target_type_id IN (
+                SELECT id FROM django_content_type WHERE app_label = 'ping'
+            )
+        """)
 
     # 2. Drop old ping tables
     cursor.execute("DROP TABLE IF EXISTS ping_pingrequest CASCADE")
@@ -46,10 +55,11 @@ def cleanup_old_apps(apps, schema_editor):
     """)
 
     # 5. Clean up permissions and content types for ping app
-    cursor.execute("""
-        DELETE FROM auth_permission
-        WHERE content_type_id IN (SELECT id FROM django_content_type WHERE app_label = 'ping')
-    """)
+    if table_exists('auth_permission'):
+        cursor.execute("""
+            DELETE FROM auth_permission
+            WHERE content_type_id IN (SELECT id FROM django_content_type WHERE app_label = 'ping')
+        """)
     cursor.execute("DELETE FROM django_content_type WHERE app_label = 'ping'")
 
 

--- a/adoorback/check_in/tests_check_in_subscribe.py
+++ b/adoorback/check_in/tests_check_in_subscribe.py
@@ -1,0 +1,371 @@
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient, APIRequestFactory
+
+from account.models import Connection, FriendRequest, Subscription
+from account.serializers import FriendListSerializer, UserProfileSerializer
+from check_in.models import CheckIn, Song
+from notification.models import Notification
+
+User = get_user_model()
+
+
+def get_check_in_ct():
+    return ContentType.objects.get_for_model(CheckIn)
+
+
+class CheckInSubscriptionDefaultTests(TestCase):
+    """Test that default subscriptions are created on friendship creation."""
+
+    def setUp(self):
+        self.user_a = User.objects.create_user(
+            username='user_a', email='a@test.com', password='pw',
+            current_ver='version_w',
+        )
+        self.user_b = User.objects.create_user(
+            username='user_b', email='b@test.com', password='pw',
+            current_ver='version_w',
+        )
+
+    def _accept_friend_request(self, requester, requestee,
+                               requester_choice='friend', requestee_choice='friend'):
+        fr = FriendRequest.objects.create(
+            requester=requester, requestee=requestee,
+            requester_choice=requester_choice, requestee_choice=requestee_choice,
+        )
+        fr.accepted = True
+        fr.save()
+        return fr
+
+    def test_close_friend_creates_subscription(self):
+        """When both set close_friend, both get subscriptions."""
+        self._accept_friend_request(
+            self.user_a, self.user_b,
+            requester_choice='close_friend', requestee_choice='close_friend',
+        )
+        ct = get_check_in_ct()
+        self.assertTrue(Subscription.objects.filter(
+            subscriber=self.user_a, subscribed_to=self.user_b, content_type=ct
+        ).exists())
+        self.assertTrue(Subscription.objects.filter(
+            subscriber=self.user_b, subscribed_to=self.user_a, content_type=ct
+        ).exists())
+
+    def test_one_close_friend_creates_one_subscription(self):
+        """Only the user who set close_friend gets a subscription."""
+        self._accept_friend_request(
+            self.user_a, self.user_b,
+            requester_choice='close_friend', requestee_choice='friend',
+        )
+        ct = get_check_in_ct()
+        # requester set close_friend → requester subscribes to requestee
+        self.assertTrue(Subscription.objects.filter(
+            subscriber=self.user_a, subscribed_to=self.user_b, content_type=ct
+        ).exists())
+        # requestee set friend → no subscription
+        self.assertFalse(Subscription.objects.filter(
+            subscriber=self.user_b, subscribed_to=self.user_a, content_type=ct
+        ).exists())
+
+    def test_regular_friend_no_subscription(self):
+        """No subscriptions when both set friend."""
+        self._accept_friend_request(
+            self.user_a, self.user_b,
+            requester_choice='friend', requestee_choice='friend',
+        )
+        ct = get_check_in_ct()
+        self.assertEqual(Subscription.objects.filter(content_type=ct).count(), 0)
+
+    def test_version_q_no_subscription(self):
+        """version_q users don't get auto-subscriptions."""
+        self.user_a.current_ver = 'version_q'
+        self.user_a.save()
+        self.user_b.current_ver = 'version_q'
+        self.user_b.save()
+
+        self._accept_friend_request(
+            self.user_a, self.user_b,
+            requester_choice='close_friend', requestee_choice='close_friend',
+        )
+        ct = get_check_in_ct()
+        self.assertEqual(Subscription.objects.filter(content_type=ct).count(), 0)
+
+
+class CheckInSubscriptionCleanupTests(TestCase):
+    """Test that subscriptions are cleaned up when Connection is deleted."""
+
+    def setUp(self):
+        self.user_a = User.objects.create_user(
+            username='user_a', email='a@test.com', password='pw',
+            current_ver='version_w',
+        )
+        self.user_b = User.objects.create_user(
+            username='user_b', email='b@test.com', password='pw',
+            current_ver='version_w',
+        )
+        self.conn = Connection.objects.create(
+            user1=self.user_a, user2=self.user_b,
+            user1_choice='close_friend', user2_choice='close_friend',
+        )
+        ct = get_check_in_ct()
+        Subscription.objects.create(subscriber=self.user_a, subscribed_to=self.user_b, content_type=ct)
+        Subscription.objects.create(subscriber=self.user_b, subscribed_to=self.user_a, content_type=ct)
+
+    def test_unfriend_removes_subscriptions(self):
+        ct = get_check_in_ct()
+        self.assertEqual(Subscription.objects.filter(content_type=ct).count(), 2)
+
+        self.conn.delete()
+
+        self.assertEqual(Subscription.objects.filter(content_type=ct).count(), 0)
+
+
+class CheckInSubscribeToggleAPITests(TestCase):
+    """Test the subscribe/unsubscribe toggle endpoints."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='me', email='me@test.com', password='pw',
+            current_ver='version_w',
+        )
+        self.friend = User.objects.create_user(
+            username='friend', email='friend@test.com', password='pw',
+            current_ver='version_w',
+        )
+        Connection.objects.create(
+            user1=self.user, user2=self.friend,
+            user1_choice='friend', user2_choice='friend',
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
+        self.subscribe_url = reverse('check-in-subscribe-add')
+        self.unsubscribe_url = reverse('check-in-subscribe-destroy', kwargs={'pk': self.friend.id})
+
+    def test_subscribe_success(self):
+        resp = self.client.post(self.subscribe_url, {'friend_id': self.friend.id})
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Subscription.objects.filter(
+            subscriber=self.user, subscribed_to=self.friend, content_type=get_check_in_ct()
+        ).exists())
+
+    def test_subscribe_duplicate_returns_400(self):
+        Subscription.objects.create(
+            subscriber=self.user, subscribed_to=self.friend, content_type=get_check_in_ct()
+        )
+        resp = self.client.post(self.subscribe_url, {'friend_id': self.friend.id})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_subscribe_non_friend_returns_400(self):
+        stranger = User.objects.create_user(
+            username='stranger', email='s@test.com', password='pw',
+            current_ver='version_w',
+        )
+        resp = self.client.post(self.subscribe_url, {'friend_id': stranger.id})
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_unsubscribe_success(self):
+        Subscription.objects.create(
+            subscriber=self.user, subscribed_to=self.friend, content_type=get_check_in_ct()
+        )
+        resp = self.client.delete(self.unsubscribe_url)
+        self.assertEqual(resp.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Subscription.objects.filter(
+            subscriber=self.user, subscribed_to=self.friend, content_type=get_check_in_ct()
+        ).exists())
+
+    def test_version_q_user_gets_403(self):
+        self.user.current_ver = 'version_q'
+        self.user.save()
+        resp = self.client.post(self.subscribe_url, {'friend_id': self.friend.id})
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class CheckInNotificationTests(TestCase):
+    """Test notification creation on check-in updates."""
+
+    def setUp(self):
+        self.author = User.objects.create_user(
+            username='author', email='author@test.com', password='pw',
+            current_ver='version_w',
+        )
+        self.subscriber = User.objects.create_user(
+            username='subscriber', email='sub@test.com', password='pw',
+            current_ver='version_w',
+        )
+        Connection.objects.create(
+            user1=self.author, user2=self.subscriber,
+            user1_choice='close_friend', user2_choice='close_friend',
+        )
+        Subscription.objects.create(
+            subscriber=self.subscriber, subscribed_to=self.author,
+            content_type=get_check_in_ct(),
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.author)
+        self.checkin_url = reverse('current-check-in')
+
+    def test_new_checkin_sends_notification(self):
+        """Creating a new check-in with content sends a notification."""
+        resp = self.client.post(self.checkin_url, {
+            'thought': 'hello world', 'visibility': ['friends'],
+        }, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        noti = Notification.objects.filter(user=self.subscriber)
+        self.assertEqual(noti.count(), 1)
+        self.assertIn('체크인', noti.first().message_ko)
+
+    def test_empty_checkin_no_notification(self):
+        """Creating a check-in with no content sends no notification."""
+        resp = self.client.post(self.checkin_url, {
+            'thought': '', 'visibility': ['friends'],
+        }, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(Notification.objects.filter(user=self.subscriber).count(), 0)
+
+    def test_update_checkin_sends_notification(self):
+        """Updating existing check-in content triggers notification."""
+        # Create initial check-in
+        CheckIn.objects.create(user=self.author, is_active=True, thought='old',
+                               visibility=['friends'])
+
+        # Update via API
+        resp = self.client.post(self.checkin_url, {
+            'thought': 'new thought', 'visibility': ['friends'],
+        }, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(Notification.objects.filter(user=self.subscriber).count(), 1)
+
+    def test_no_change_no_notification(self):
+        """Updating with same content doesn't trigger notification."""
+        CheckIn.objects.create(user=self.author, is_active=True, thought='same',
+                               visibility=['friends'])
+
+        resp = self.client.post(self.checkin_url, {
+            'thought': 'same', 'visibility': ['friends'],
+        }, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(Notification.objects.filter(user=self.subscriber).count(), 0)
+
+    def test_batching_within_5_minutes(self):
+        """Multiple updates within 5 min produce only 1 notification."""
+        self.client.post(self.checkin_url, {
+            'thought': 'first', 'visibility': ['friends'],
+        }, format='json')
+        self.assertEqual(Notification.objects.filter(user=self.subscriber).count(), 1)
+
+        self.client.post(self.checkin_url, {
+            'thought': 'second', 'visibility': ['friends'],
+        }, format='json')
+        # Still only 1 notification (updated, not duplicated)
+        self.assertEqual(Notification.objects.filter(user=self.subscriber).count(), 1)
+
+        noti = Notification.objects.filter(user=self.subscriber).first()
+        self.assertIn('체크인', noti.message_ko)
+
+    def test_song_change_sends_notification(self):
+        """Creating a song when there's an active check-in sends notification."""
+        CheckIn.objects.create(user=self.author, is_active=True, thought='hi')
+
+        song_url = reverse('current-song')
+        resp = self.client.post(song_url, {'track_id': 'spotify:123'}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(Notification.objects.filter(user=self.subscriber).count(), 1)
+
+    def test_song_without_checkin_no_notification(self):
+        """Creating a song without active check-in sends no notification."""
+        song_url = reverse('current-song')
+        resp = self.client.post(song_url, {'track_id': 'spotify:123'}, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        self.assertEqual(Notification.objects.filter(user=self.subscriber).count(), 0)
+
+    def test_version_q_author_no_notification(self):
+        """version_q author's check-in doesn't trigger notifications."""
+        self.author.current_ver = 'version_q'
+        self.author.save()
+
+        self.client.post(self.checkin_url, {
+            'thought': 'hello', 'visibility': ['friends'],
+        }, format='json')
+        self.assertEqual(Notification.objects.filter(user=self.subscriber).count(), 0)
+
+
+class CheckInSubscriptionSerializerTests(TestCase):
+    """Test that is_check_in_subscribed appears correctly in serializers."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='me', email='me@test.com', password='pw',
+            current_ver='version_w',
+        )
+        self.friend = User.objects.create_user(
+            username='friend', email='friend@test.com', password='pw',
+            current_ver='version_w',
+        )
+        Connection.objects.create(
+            user1=self.user, user2=self.friend,
+            user1_choice='close_friend', user2_choice='friend',
+        )
+        self.factory = APIRequestFactory()
+
+    def test_profile_subscribed_true(self):
+        Subscription.objects.create(
+            subscriber=self.user, subscribed_to=self.friend,
+            content_type=get_check_in_ct(),
+        )
+        request = self.factory.get('/')
+        request.user = self.user
+        serializer = UserProfileSerializer(self.friend, context={'request': request})
+        self.assertTrue(serializer.data['is_check_in_subscribed'])
+
+    def test_profile_not_subscribed_false(self):
+        request = self.factory.get('/')
+        request.user = self.user
+        serializer = UserProfileSerializer(self.friend, context={'request': request})
+        self.assertFalse(serializer.data['is_check_in_subscribed'])
+
+    def test_friend_list_uses_batch_context(self):
+        Subscription.objects.create(
+            subscriber=self.user, subscribed_to=self.friend,
+            content_type=get_check_in_ct(),
+        )
+        request = self.factory.get('/')
+        request.user = self.user
+        context = {
+            'request': request,
+            'check_in_subscription_ids': {self.friend.id},
+            'favorite_ids': set(),
+            'hidden_ids': set(),
+            'connection_by_friend_id': {},
+            'visible_check_in_by_user_id': {},
+            'active_song_by_user_id': {},
+            'unread_note_count_by_author': {},
+            'unread_response_count_by_author': {},
+            'unread_chat_count_by_friend_id': {},
+            'visible_notes_by_author': {},
+            'visible_resps_by_author': {},
+            'pokes_by_receiver': {},
+        }
+        serializer = FriendListSerializer(self.friend, context=context)
+        self.assertTrue(serializer.data['is_check_in_subscribed'])
+
+    def test_version_q_always_false(self):
+        self.user.current_ver = 'version_q'
+        self.user.save()
+        Subscription.objects.create(
+            subscriber=self.user, subscribed_to=self.friend,
+            content_type=get_check_in_ct(),
+        )
+        request = self.factory.get('/')
+        request.user = self.user
+        serializer = UserProfileSerializer(self.friend, context={'request': request})
+        self.assertFalse(serializer.data['is_check_in_subscribed'])

--- a/adoorback/check_in/views.py
+++ b/adoorback/check_in/views.py
@@ -21,6 +21,79 @@ import check_in.serializers as cs
 User = get_user_model()
 
 
+# --- Check-in subscription notification helpers ---
+
+CONTENT_FIELDS = ('mood', 'social_battery', 'thought')
+
+
+def _has_visible_content(check_in, has_active_song=False):
+    """Check if the check-in has any non-empty user-visible content."""
+    return (
+        bool(check_in.mood)
+        or bool(check_in.social_battery)
+        or bool(check_in.thought)
+        or has_active_song
+    )
+
+
+def notify_check_in_subscribers(check_in):
+    """Send notifications to check-in subscribers (version_w only, 5-min batching)."""
+    from adoorback.utils.content_types import get_check_in_type
+    from notification.models import Notification, NotificationActor
+    from account.models import Subscription
+
+    user = check_in.user
+    if user.current_ver != 'version_w':
+        return
+
+    check_in_ct = get_check_in_type()
+    subscriber_ids = list(Subscription.objects.filter(
+        subscribed_to=user, content_type=check_in_ct
+    ).values_list('subscriber_id', flat=True))
+
+    if not subscriber_ids:
+        return
+
+    blocked_ids = user.user_report_blocked_ids
+
+    for subscriber_id in subscriber_ids:
+        if subscriber_id in blocked_ids:
+            continue
+
+        recent_noti = _find_recent_check_in_noti(subscriber_id, user)
+
+        if recent_noti:
+            recent_noti.notification_updated_at = timezone.now()
+            recent_noti.target = check_in
+            recent_noti.save()
+        else:
+            noti = Notification.objects.create(
+                user_id=subscriber_id,
+                origin=user,
+                target=check_in,
+                message_ko=f"{user.username}님이 체크인을 업데이트했습니다!",
+                message_en=f"{user.username} updated their check-in!",
+                redirect_url=f"/users/{user.username}",
+            )
+            NotificationActor.objects.create(user=user, notification=noti)
+
+
+def _find_recent_check_in_noti(subscriber_id, actor):
+    """Find a recent (within 5 min) unread check-in notification from this actor."""
+    from notification.models import Notification
+
+    cutoff = timezone.now() - timezone.timedelta(minutes=5)
+    check_in_ct = ContentType.objects.get_for_model(CheckIn)
+    return Notification.objects.filter(
+        user_id=subscriber_id,
+        actors__in=[actor],
+        target_type=check_in_ct,
+        is_read=False,
+        is_visible=True,
+        notification_updated_at__gte=cutoff,
+    ).order_by('-notification_updated_at').first()
+
+
 class CurrentCheckIn(generics.ListCreateAPIView):
     """
     Get current active check-in of request user or create a new check-in.
@@ -42,14 +115,27 @@ class CurrentCheckIn(generics.ListCreateAPIView):
         ).first()
 
         if existing_checkin:
+            # Snapshot content before update
+            old_content = {f: getattr(existing_checkin, f) for f in CONTENT_FIELDS}
+
             # Update existing check-in
             for field, value in serializer.validated_data.items():
                 setattr(existing_checkin, field, value)
             existing_checkin.save()
             serializer.instance = existing_checkin
+
+            # Notify only if content actually changed and result is non-empty
+            new_content = {f: getattr(existing_checkin, f) for f in CONTENT_FIELDS}
+            if old_content != new_content:
+                has_song = Song.objects.filter(user=current_user, is_active=True).exists()
+                if _has_visible_content(existing_checkin, has_song):
+                    notify_check_in_subscribers(existing_checkin)
         else:
             # Create new check-in
             serializer.save(user=current_user, is_active=True)
+            has_song = Song.objects.filter(user=current_user, is_active=True).exists()
+            if _has_visible_content(serializer.instance, has_song):
+                notify_check_in_subscribers(serializer.instance)
 
         return Response(serializer.data)
 
@@ -184,6 +270,11 @@ class CurrentSong(generics.ListCreateAPIView):
         # to bypass CheckIn.save()'s per-field timestamp logic.
         CheckIn.objects.filter(user=current_user, is_active=True) \
                        .update(song_updated_at=timezone.now())
+
+        # Notify check-in subscribers about song change
+        active_check_in = CheckIn.objects.filter(user=current_user, is_active=True).first()
+        if active_check_in:
+            notify_check_in_subscribers(active_check_in)
 
         return Response(serializer.data)
 


### PR DESCRIPTION
# Check-In Subscription API (Version W Only)

Subscribe to a friend's check-in updates and receive push notifications when they update.

---

## Default Behavior

When a friendship is created, **close friends** are auto-subscribed to each other's check-ins. Regular friends are not subscribed by default. After that, the user can toggle manually.

---

## New Endpoints

### Subscribe to a friend's check-in

```
POST /api/user/friends/check-in-subscribe/
```

**Body:**
```json
{ "friend_id": 42 }
```

**Responses:**
| Status | Description |
|--------|-------------|
| 201 | Subscribed successfully |
| 400 | Already subscribed / not a friend / missing friend_id |
| 403 | User is not on version_w |

---

### Unsubscribe from a friend's check-in

```
DELETE /api/user/friends/{friend_user_id}/check-in-subscribe/
```

**Responses:**
| Status | Description |
|--------|-------------|
| 204 | Unsubscribed successfully |
| 404 | Subscription not found |
| 403 | User is not on version_w |

---

## Updated Fields in Existing Endpoints

### `GET /api/user/friends/` (Friend List)

New field added to each friend object:

```json
{
  "is_check_in_subscribed": true
}
```

---

### `GET /api/user/{username}/profile/` (User Profile)

New field added:

```json
{
  "is_check_in_subscribed": false
}
```

---

### `GET /api/user/feed/` and `GET /api/user/feed/full/` (Friend Feed)

New field added inside `author_detail` of each feed item:

```json
{
  "author_detail": {
    "id": 42,
    "username": "alice",
    "is_check_in_subscribed": true
  }
}
```

> Only injected for version_w users. For version_q users, this field is absent.

---

## Notifications

When a subscribed friend updates their check-in, the subscriber receives a push notification:

- **Korean:** `{username}님이 체크인을 업데이트했습니다!`
- **English:** `{username} updated their check-in!`
- **redirect_url:** `/users/{username}`
- **notification_type:** `CheckIn`

### Batching

Multiple updates from the same friend within **5 minutes** produce only **one** notification (timestamp is refreshed, no duplicate created).

### Triggers

| Action | Notification? |
|--------|--------------|
| New check-in with content | Yes |
| Update check-in content (mood/thought/battery) | Yes (if content actually changed and result is non-empty) |
| New song added | Yes (if active check-in exists) |
| Delete check-in | No |
| Delete song | No |
| Only visibility changed | No |
| All content cleared | No |

---

## Version Gating

All subscription features are **version_w only**:

- `is_check_in_subscribed` returns `false` for version_q users
- Subscribe/unsubscribe endpoints return `403` for version_q users
- No notifications are sent for version_q authors
- Auto-subscription on friendship is skipped for version_q users
