### PR TITLE
bugfix: #902 채팅 요청 푸시 노티 미발송 버그 수정

### DIFF
--- a/adoorback/notification/models.py
+++ b/adoorback/notification/models.py
@@ -220,9 +220,12 @@ def notify_firebase(instance):
 
 @receiver(post_save, sender=Notification)
 def send_firebase_notification(sender, instance, created, **kwargs):
-    is_any_actor_active = instance.actors.filter(deleted__isnull=True).exists()
-    if (created or (not created and instance.is_visible and not instance.is_read)) and is_any_actor_active:
+    if created:
         notify_firebase(instance)
+    elif instance.is_visible and not instance.is_read:
+        is_any_actor_active = instance.actors.filter(deleted__isnull=True).exists()
+        if is_any_actor_active:
+            notify_firebase(instance)
 
 
 @receiver(post_save, sender=Notification)


### PR DESCRIPTION
# 채팅 요청 푸시 노티 미발송 버그 수정

## Context

채팅 요청을 보낼 때 `Notification` 객체는 정상적으로 생성되지만, 실제 FCM 푸시 노티피케이션이 디바이스에 전달되지 않는 문제가 있다. 원인은 `Notification` 모델의 `post_save` 시그널에서 **아직 생성되지 않은 `NotificationActor`를 검사**하는 타이밍 버그이다.

## Root Cause

[notification/models.py:221-225](WhoamI-Today-backend/adoorback/notification/models.py#L221-L225)의 `send_firebase_notification` 시그널:

```python
@receiver(post_save, sender=Notification)
def send_firebase_notification(sender, instance, created, **kwargs):
    is_any_actor_active = instance.actors.filter(deleted__isnull=True).exists()
    if (created or (not created and instance.is_visible and not instance.is_read)) and is_any_actor_active:
        notify_firebase(instance)
```

**문제 흐름:**
1. `Notification.objects.create(...)` 호출 → `post_save` 시그널 즉시 발동
2. 시그널에서 `instance.actors.exists()` 체크 → `NotificationActor`가 아직 없음 → `False`
3. `notify_firebase()` 호출되지 않음
4. 그 다음 줄에서야 `NotificationActor.objects.create(...)` 실행

**영향 범위:** 채팅 요청뿐 아니라, 새로 생성되는 **모든** 노티피케이션의 첫 번째 푸시가 실패한다 (chat, comment, friend request, note, check_in, user_tag 등). 좋아요/리액션 등의 aggregation update 경로는 이전 actor가 이미 존재하므로 정상 작동.

## Fix

[notification/models.py](WhoamI-Today-backend/adoorback/notification/models.py) 한 파일만 수정:

```python
@receiver(post_save, sender=Notification)
def send_firebase_notification(sender, instance, created, **kwargs):
    if created:
        notify_firebase(instance)
    elif instance.is_visible and not instance.is_read:
        is_any_actor_active = instance.actors.filter(deleted__isnull=True).exists()
        if is_any_actor_active:
            notify_firebase(instance)
```

- `created=True`: actor 체크 없이 바로 푸시 전송 (모든 call site에서 Notification 생성 직후 반드시 NotificationActor를 생성하므로 안전)
- `created=False` (update): 기존 로직 유지 (unlike 등으로 actor가 모두 삭제된 경우 푸시 방지)

## Verification

1. `python manage.py test chat.tests_chat_request` - 채팅 요청 테스트
2. `python manage.py test notification` - 노티피케이션 테스트
3. 수동 테스트: 채팅 요청 보낸 후 상대방 디바이스에서 푸시 수신 확인
4. Slack 에러 로그에서 FCM 발송 실패 여부 모니터링
