### PR TITLE
bugfix: #906 Deactivate Unregistered FCM Devices

### DIFF
--- a/adoorback/notification/models.py
+++ b/adoorback/notification/models.py
@@ -15,6 +15,7 @@ from notification.helpers import find_like_noti, construct_message
 
 from firebase_admin.messaging import Message
 from firebase_admin.messaging import Notification as FirebaseNotification
+from firebase_admin._messaging_utils import UnregisteredError
 from custom_fcm.models import CustomFCMDevice
 from safedelete.models import SafeDeleteModel
 from safedelete.models import SOFT_DELETE_CASCADE, HARD_DELETE
@@ -208,6 +209,9 @@ def notify_firebase(instance):
         )
         try:
             device.send_message(message)
+        except UnregisteredError:
+            device.active = False
+            device.save()
         except Exception as e:
             stack_trace = traceback.format_exc()
             send_msg_to_slack(


### PR DESCRIPTION
# Fix: Deactivate Unregistered FCM Devices

## Problem
Firebase push notifications repeatedly failed for devices with invalid FCM tokens, producing `UnregisteredError` on every send attempt.

## Cause
FCM tokens become invalid when a user uninstalls the app, reinstalls it, or revokes notification permissions. The server was still attempting to send to these stale tokens.

## Change
- **File**: `adoorback/notification/models.py`
- Added `UnregisteredError` handling in `notify_firebase()`
- When caught, the device is set to `active=False` so no further attempts are made
- Other exceptions continue to be logged to Slack as before

## Impact
- No effect on valid devices — notifications are delivered normally
- Eliminates repeated error logs for invalid tokens
- Users who reopen the app will register a new token automatically
