### PR TITLE
(#908) Poke Daily Limit Error Alerting

### DIFF
--- a/adoorback/adoorback/utils/validators.py
+++ b/adoorback/adoorback/utils/validators.py
@@ -4,7 +4,7 @@ import traceback
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
-from rest_framework.exceptions import NotAuthenticated, AuthenticationFailed, PermissionDenied
+from rest_framework.exceptions import NotAuthenticated, AuthenticationFailed, PermissionDenied, Throttled
 from rest_framework.views import exception_handler
 
 from adoorback.utils.alerts import send_msg_to_slack, send_gmail_alert
@@ -52,8 +52,8 @@ def adoor_exception_handler(exc, context):
             return exception_handler(exc, context)
 
     # Slack notification
-    # Ignore authentication failures and user input related exceptions
-    if isinstance(exc, (NotAuthenticated, AuthenticationFailed)) or isinstance(exc, USER_INPUT_EXCEPTIONS):
+    # Ignore authentication failures, throttling, and user input related exceptions
+    if isinstance(exc, (NotAuthenticated, AuthenticationFailed, Throttled)) or isinstance(exc, USER_INPUT_EXCEPTIONS):
         return exception_handler(exc, context)
 
     slack_level = getattr(exc, 'slack_level', 'ERROR')  # Default is ERROR


### PR DESCRIPTION
# Fix: Poke Daily Limit UX & Error Alerting

## Problem
- Users received no feedback when hitting the daily poke limit (button silently did nothing)
- Backend sent Slack error alerts for `Throttled` exceptions, which are intentional rate limits — not real errors

## Changes

### Backend (`adoorback/utils/validators.py`)
- Added `Throttled` to the exception types skipped by Slack alerting in `adoor_exception_handler`
- DRF still returns a proper 429 response to the client

### Frontend (`PokeButton.tsx`)
- Catch 429 responses and display a toast: "Today's ping limit reached! Try again tomorrow."
- Non-429 errors remain silent (unchanged behavior)
- Added `useTranslation` with i18n support (EN/KO)

### i18n
- **EN**: `"Today's ping limit reached! Try again tomorrow."`
- **KO**: `"오늘의 핑 횟수를 모두 사용했어요! 내일 다시 시도해주세요."`

## Impact
- Valid pokes: no change
- Rate-limited pokes: user now sees a clear toast message
- Slack alerts: no longer fires for expected throttle responses
