### PR TITLE
feat(version): dispatch FCM silent push on current_ver change for ins…

### DIFF
--- a/adoorback/account/apps.py
+++ b/adoorback/account/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class AccountConfig(AppConfig):
     name = 'account'
     default_auto_field = 'django.db.models.AutoField'
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/adoorback/account/signals.py
+++ b/adoorback/account/signals.py
@@ -1,0 +1,65 @@
+import contextlib
+import threading
+
+from django.db import transaction
+from django.db.models.signals import post_save, pre_save
+from django.dispatch import receiver
+
+from .models import User
+
+
+_thread_local = threading.local()
+
+
+@contextlib.contextmanager
+def suppress_version_push():
+    """Context manager to prevent current_ver change signals from firing
+    silent pushes. Used by management commands (e.g. `swap_versions --no-push`)
+    and tests.
+    """
+    _thread_local.suppress_version_push = True
+    try:
+        yield
+    finally:
+        _thread_local.suppress_version_push = False
+
+
+@receiver(pre_save, sender=User)
+def _capture_original_current_ver(sender, instance, update_fields=None, **kwargs):
+    if not instance.pk:
+        instance._original_current_ver = None
+        return
+    if update_fields is not None and 'current_ver' not in update_fields:
+        instance._original_current_ver = None
+        return
+    try:
+        instance._original_current_ver = (
+            User.objects.only('current_ver').get(pk=instance.pk).current_ver
+        )
+    except User.DoesNotExist:
+        instance._original_current_ver = None
+
+
+@receiver(post_save, sender=User)
+def _notify_version_change(sender, instance, created, update_fields=None, **kwargs):
+    if created:
+        return
+    if getattr(_thread_local, 'suppress_version_push', False):
+        return
+    if update_fields is not None and 'current_ver' not in update_fields:
+        return
+    original = getattr(instance, '_original_current_ver', None)
+    if original is None or original == instance.current_ver:
+        return
+
+    new_ver = instance.current_ver
+    ver_changed_at = (
+        instance.ver_changed_at.isoformat() if instance.ver_changed_at else ""
+    )
+
+    def _dispatch():
+        # Lazy import avoids any import-time cycle between account <-> custom_fcm.
+        from custom_fcm.silent_push import send_version_change_push
+        send_version_change_push(instance, new_ver, ver_changed_at)
+
+    transaction.on_commit(_dispatch)

--- a/adoorback/adoorback/management/commands/swap_versions.py
+++ b/adoorback/adoorback/management/commands/swap_versions.py
@@ -1,6 +1,10 @@
+import contextlib
+
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.utils import timezone
+
+from account.signals import suppress_version_push
 
 User = get_user_model()
 
@@ -17,6 +21,10 @@ class Command(BaseCommand):
             '--user-ids', nargs='*', type=int,
             help='Only swap specific user IDs (default: all non-superusers).'
         )
+        parser.add_argument(
+            '--no-push', action='store_true',
+            help='Skip dispatching silent pushes for the current_ver changes.'
+        )
 
     def handle(self, *args, **options):
         queryset = User.objects.exclude(is_superuser=True)
@@ -25,14 +33,17 @@ class Command(BaseCommand):
 
         now = timezone.now()
         count = 0
-        for user in queryset:
-            old_ver = user.current_ver
-            user.current_ver = 'version_q' if old_ver == 'version_w' else 'version_w'
-            user.ver_changed_at = now
-            if not options['dry_run']:
-                user.save(update_fields=['current_ver', 'ver_changed_at'])
-            self.stdout.write(f'  {user.username}: {old_ver} -> {user.current_ver}')
-            count += 1
+        push_ctx = suppress_version_push() if options['no_push'] else contextlib.nullcontext()
+        with push_ctx:
+            for user in queryset:
+                old_ver = user.current_ver
+                user.current_ver = 'version_q' if old_ver == 'version_w' else 'version_w'
+                user.ver_changed_at = now
+                if not options['dry_run']:
+                    user.save(update_fields=['current_ver', 'ver_changed_at'])
+                self.stdout.write(f'  {user.username}: {old_ver} -> {user.current_ver}')
+                count += 1
 
         action = 'Would swap' if options['dry_run'] else 'Swapped'
-        self.stdout.write(self.style.SUCCESS(f'{action} {count} users.'))
+        push_note = ' (pushes suppressed)' if options['no_push'] and not options['dry_run'] else ''
+        self.stdout.write(self.style.SUCCESS(f'{action} {count} users.{push_note}'))

--- a/adoorback/custom_fcm/silent_push.py
+++ b/adoorback/custom_fcm/silent_push.py
@@ -1,0 +1,72 @@
+import traceback
+from typing import Optional
+
+from firebase_admin.messaging import (
+    AndroidConfig,
+    APNSConfig,
+    APNSPayload,
+    Aps,
+    Message,
+)
+from firebase_admin._messaging_utils import UnregisteredError
+
+from adoorback.utils.alerts import send_msg_to_slack
+
+from .models import CustomFCMDevice
+
+
+def send_version_change_push(
+    user,
+    new_ver: str,
+    ver_changed_at: Optional[str] = None,
+) -> int:
+    """Send a data-only silent push to every active device for `user`.
+
+    Data-only means no `notification=` field — required for iOS to honor
+    `content-available: 1` and wake the app in the background without
+    showing UI. On Android, `priority=high` wakes the app promptly even
+    in Doze.
+
+    Returns the number of devices successfully dispatched to.
+    """
+    devices = CustomFCMDevice.objects.filter(user_id=user.id, active=True)
+    data = {
+        "type": "version_change",
+        "new_ver": new_ver,
+        "ver_changed_at": ver_changed_at or "",
+        "content-available": "1",
+        "priority": "high",
+    }
+    sent = 0
+    for device in devices:
+        message = Message(
+            data=data,
+            android=AndroidConfig(priority="high"),
+            apns=APNSConfig(
+                headers={
+                    "apns-push-type": "background",
+                    "apns-priority": "5",
+                },
+                payload=APNSPayload(aps=Aps(content_available=True)),
+            ),
+        )
+        try:
+            device.send_message(message)
+            sent += 1
+        except UnregisteredError:
+            device.active = False
+            device.save()
+        except Exception as e:
+            stack_trace = traceback.format_exc()
+            send_msg_to_slack(
+                text=(
+                    f"🚨 Failed to send silent version-change push to device "
+                    f"{device.id} (user {user.id}): {e}\n```{stack_trace}```"
+                ),
+                level="ERROR",
+            )
+            print(
+                f"🚨 Failed to send silent version-change push to device "
+                f"{device.id}: {e}\n{stack_trace}"
+            )
+    return sent


### PR DESCRIPTION
…tant client sync

- Add custom_fcm/silent_push.py::send_version_change_push: data-only FCM message with APNs background push-type + content_available, Android priority=high, and UnregisteredError → device.active=False handling (same pattern as notify_firebase)
- Add account/signals.py with pre_save/post_save hooks to detect current_ver field changes across admin, API, and management-command paths; dispatch via transaction.on_commit; expose suppress_version_push context manager for staged rollouts
- Wire account.apps.AccountConfig.ready() to register signals
- Add --no-push flag to swap_versions command so legacy clients don't trigger noisy pushes during the initial rollout window

## Issue Number:

## Self Check List

- [ ] Have you double-checked the base branch into which this PR will be merged?
- [ ] Have you rebased from the base branch?

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (formatting, renaming)
- [ ] Merge Develop to Main
- [ ] Other (please describe):

## What does this PR do?

## Preview Image

## Further comments
