### PR TITLE
feat(check_in): manual per-component archive endpoint

### DIFF
--- a/adoorback/check_in/urls.py
+++ b/adoorback/check_in/urls.py
@@ -8,6 +8,8 @@ urlpatterns = [
     path('latest-visibility/', views.CurrentUserLatestCheckInVisibility.as_view(), name='current-user-latest-check-in-visibility'),
     path('latest/', views.LatestCheckIn.as_view(), name='latest-check-in'),
 
+    path('components/<str:component>/archive/', views.ArchiveLiveComponent.as_view(), name='archive-live-component'),
+
     path('entries/', views.OwnArchiveEntries.as_view(), name='own-archive-entries'),
     path('entries/<int:pk>/', views.ArchiveEntryDelete.as_view(), name='archive-entry-delete'),
     path('entries/<int:pk>/pin/', views.ArchiveEntryPinToggle.as_view(), name='archive-entry-pin'),

--- a/adoorback/check_in/views.py
+++ b/adoorback/check_in/views.py
@@ -352,6 +352,82 @@ class ArchiveEntryDelete(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+class ArchiveLiveComponent(APIView):
+    """PATCH /api/check_in/components/<component>/archive/
+
+    Archive the user's currently-live entry for `component` without
+    replacing it with new content. The component's value on the active
+    CheckIn is cleared (or, for `song`, the active Song row is
+    deactivated), which routes through the existing CheckIn.save /
+    Song post_save diff logic and stamps `superseded_at` on the live
+    CheckInComponentEntry. Friend cards immediately show the empty
+    placeholder for that component, and the archived entry surfaces
+    under "Today" in the owner's archive feed (eligible for pinning).
+
+    Idempotent at the entry level: a 404 is returned when the
+    component has no live value to archive.
+    """
+    permission_classes = [IsAuthenticated]
+    ALLOWED = ('battery', 'mood', 'thought', 'song')
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    @transaction.atomic
+    def patch(self, request, component):
+        if component not in self.ALLOWED:
+            return Response(
+                {'detail': f'component must be one of {list(self.ALLOWED)}.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user = request.user
+
+        if component == 'song':
+            active_songs = list(Song.objects.filter(user=user, is_active=True))
+            if not active_songs:
+                return Response(
+                    {'detail': 'No active song to archive.'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            for song in active_songs:
+                song.is_active = False
+                song.save()  # post_save signal supersedes the live song entry
+            return Response({'archived': component}, status=status.HTTP_200_OK)
+
+        check_in = CheckIn.objects.filter(user=user, is_active=True).first()
+        if not check_in:
+            return Response(
+                {'detail': 'No active check-in.'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        if component == 'battery':
+            if not check_in.social_battery:
+                return Response(
+                    {'detail': 'No active battery to archive.'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            check_in.social_battery = None
+        elif component == 'mood':
+            if not check_in.mood:
+                return Response(
+                    {'detail': 'No active mood to archive.'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            check_in.mood = []
+        elif component == 'thought':
+            if not check_in.thought:
+                return Response(
+                    {'detail': 'No active thought to archive.'},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+            check_in.thought = ''
+
+        check_in.save()  # diff path supersedes the matching live entry
+        return Response({'archived': component}, status=status.HTTP_200_OK)
+
+
 class OwnArchiveEntries(generics.ListAPIView):
     """GET /check_in/entries/?tab=all|pinned&cursor=...
 


### PR DESCRIPTION
## Summary
- New PATCH /api/check_in/components/<component>/archive/ endpoint
- Lets the owner archive a single live component (battery / mood / thought / song) without replacing it
- Routes through existing CheckIn.save / Song post_save signal so the live entry's superseded_at is stamped via the same diff path a normal save uses
- 200 on success, 404 when nothing live, 400 for unknown component, 401 unauthenticated

## Test plan
- [x] APIClient verification for each of the 4 components — entry superseded, CheckIn field cleared / Song deactivated
- [x] 404 on second-archive idempotency check
- [x] 400 on bogus component name
- [x] check_in test suite same pre-existing fail/error counts (no regressions)