### PR TITLE
(#893) Experiment Phase Reset

### DIFF
--- a/adoorback/adoorback/management/commands/reset_experiment_data.py
+++ b/adoorback/adoorback/management/commands/reset_experiment_data.py
@@ -1,0 +1,270 @@
+import os
+import shutil
+import subprocess
+from datetime import datetime
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = (
+        'Reset all user-generated content for the experiment phase swap. '
+        'Takes a pg_dump backup first, then hard-deletes content via raw SQL '
+        '(bypassing Django signals and SafeDelete). '
+        'Preserves: Connections, ChatRooms, Messages, User accounts, Questions.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run', action='store_true',
+            help='Show record counts per table without deleting anything.',
+        )
+        parser.add_argument(
+            '--skip-backup', action='store_true',
+            help='Skip the pg_dump backup step (development only).',
+        )
+        parser.add_argument(
+            '--no-input', action='store_true',
+            help='Skip the confirmation prompt (for scripted use).',
+        )
+        parser.add_argument(
+            '--backup-dir', type=str, default=None,
+            help='Directory for the backup file (default: <project_root>/backups/).',
+        )
+
+    def _get_m2m_table_names(self):
+        """Resolve auto-generated M2M junction table names at runtime."""
+        from account.models import Interest, Persona, User
+        from check_in.models import CheckIn
+        from note.models import Note
+        from qna.models import Response
+        return {
+            # Content readers (must be cleared before parent tables)
+            'response_readers': Response.readers.through._meta.db_table,
+            'note_readers': Note.readers.through._meta.db_table,
+            'check_in_readers': CheckIn.readers.through._meta.db_table,
+            # User-level M2M
+            'favorites': User.favorites.through._meta.db_table,
+            'hidden': User.hidden.through._meta.db_table,
+            'interest_users': Interest.users.through._meta.db_table,
+            'persona_users': Persona.users.through._meta.db_table,
+        }
+
+    def _get_tables_to_delete(self):
+        """Return ordered list of (label, table_name, where_clause) for deletion.
+
+        Order respects FK dependencies: children before parents.
+        """
+        return [
+            # Layer 1: Leaf nodes
+            ('NotificationActor', 'notification_notificationactor', None),
+            ('UserTag', 'user_tag_usertag', None),
+            ('CustomChip', 'account_customchip', None),
+            ('PlaylistFeed', 'playlist_playlistfeed', None),
+            ('DiscoverFeed', 'account_discoverfeed', None),
+            ('DiscoverFeedMusic', 'account_discoverfeedmusic', None),
+
+            # Layer 2: Referenced by Layer 1 (now cleared)
+            ('Notification', 'notification_notification', None),
+            ('Like', 'like_like', None),
+            ('Reaction', 'reaction_reaction', None),
+            ('ContentReport', 'content_report_contentreport', None),
+
+            # Layer 3: Comment (self-referential replies)
+            ('Comment', 'comment_comment', None),
+
+            # Layer 4: Content tables
+            ('NoteImage', 'note_noteimage', None),
+            ('Note', 'note_note', None),
+            ('ResponseRequest', 'qna_responserequest', None),
+            ('Response', 'qna_response', None),
+
+            # Layer 5: Check-in related
+            ('Poke', 'check_in_poke', None),
+            ('CheckIn', 'check_in_checkin', None),
+            ('Song', 'check_in_song', None),
+
+            # Layer 6: Supporting tables
+            ('Subscription', 'account_subscription', None),
+
+            # Layer 7: Pending friend requests only
+            ('FriendRequest (pending)', 'account_friendrequest', 'accepted IS NULL'),
+        ]
+
+    def _run_backup(self, backup_dir):
+        """Run pg_dump and return the backup file path."""
+        db = settings.DATABASES['default']
+        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+        filename = f"whoamitoday_pre_reset_{timestamp}.dump"
+        filepath = os.path.join(backup_dir, filename)
+
+        env = os.environ.copy()
+        env['PGPASSWORD'] = db['PASSWORD']
+
+        cmd = [
+            'pg_dump', '-Fc',
+            '-h', db.get('HOST', 'localhost'),
+            '-p', str(db.get('PORT', '5432')),
+            '-U', db.get('USER', 'postgres'),
+            '-d', db['NAME'],
+            '-f', filepath,
+        ]
+
+        self.stdout.write(f'  Running: {" ".join(cmd[:2])} ... -f {filepath}')
+        result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+
+        if result.returncode != 0:
+            self.stderr.write(self.style.ERROR(f'  pg_dump failed: {result.stderr}'))
+            return None
+
+        size_mb = os.path.getsize(filepath) / (1024 * 1024)
+        self.stdout.write(self.style.SUCCESS(f'  Backup saved: {filepath} ({size_mb:.1f} MB)'))
+        return filepath
+
+    def _count_rows(self, cursor, table, where=None):
+        """Return row count for a table, optionally with a WHERE clause."""
+        sql = f'SELECT COUNT(*) FROM {table}'
+        if where:
+            sql += f' WHERE {where}'
+        try:
+            cursor.execute(sql)
+            return cursor.fetchone()[0]
+        except Exception:
+            return -1
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        skip_backup = options['skip_backup']
+        no_input = options['no_input']
+
+        # Resolve backup directory
+        if options['backup_dir']:
+            backup_dir = options['backup_dir']
+        else:
+            backup_dir = os.path.join(settings.BASE_DIR, '..', 'backups')
+        backup_dir = os.path.abspath(backup_dir)
+
+        m2m_tables = self._get_m2m_table_names()
+        tables_to_delete = self._get_tables_to_delete()
+
+        # --- Pre-flight: count records ---
+        self.stdout.write(self.style.MIGRATE_HEADING('\n=== Experiment Data Reset ===\n'))
+
+        with connection.cursor() as cursor:
+            self.stdout.write('M2M junction tables (to be cleared):')
+            total = 0
+            for name, table in m2m_tables.items():
+                count = self._count_rows(cursor, table)
+                total += max(count, 0)
+                self.stdout.write(f'  {name:30s} {count:>8,}')
+
+            self.stdout.write('\nContent tables (to be deleted):')
+            for label, table, where in tables_to_delete:
+                count = self._count_rows(cursor, table, where)
+                total += max(count, 0)
+                suffix = f' (WHERE {where})' if where else ''
+                self.stdout.write(f'  {label:30s} {count:>8,}{suffix}')
+
+            self.stdout.write(f'\n  {"TOTAL":30s} {total:>8,} records')
+
+        # --- Profile fields to reset ---
+        with connection.cursor() as cursor:
+            cursor.execute(
+                "SELECT COUNT(*) FROM account_user "
+                "WHERE is_superuser = FALSE AND deleted IS NULL"
+            )
+            user_count = cursor.fetchone()[0]
+        self.stdout.write(f'\nUser profile fields to reset: {user_count} users')
+        self.stdout.write('  Fields: persona -> [], interests_updated_at -> NULL, '
+                          'personas_updated_at -> NULL, last_interest_card_category -> NULL')
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING('\n[DRY RUN] No changes made.'))
+            return
+
+        # --- Confirmation ---
+        if not no_input:
+            self.stdout.write(self.style.WARNING(
+                f'\nThis will permanently delete {total:,} records and reset {user_count} user profiles.'
+            ))
+            confirm = input('Type "RESET" to proceed: ')
+            if confirm != 'RESET':
+                self.stdout.write(self.style.ERROR('Aborted.'))
+                return
+
+        # --- Backup ---
+        if not skip_backup:
+            self.stdout.write(self.style.MIGRATE_HEADING('\n--- Step 1: Database Backup ---'))
+            os.makedirs(backup_dir, exist_ok=True)
+
+            if not shutil.which('pg_dump'):
+                self.stderr.write(self.style.ERROR('pg_dump not found on PATH. Aborting.'))
+                return
+
+            backup_path = self._run_backup(backup_dir)
+            if not backup_path:
+                self.stderr.write(self.style.ERROR('Backup failed. Aborting reset.'))
+                return
+        else:
+            self.stdout.write(self.style.WARNING('\n--- Step 1: Backup SKIPPED (--skip-backup) ---'))
+            backup_path = None
+
+        # --- Delete data in a single transaction ---
+        self.stdout.write(self.style.MIGRATE_HEADING('\n--- Step 2: Deleting Data ---'))
+
+        with connection.cursor() as cursor:
+            # All deletions in one transaction
+            deleted_counts = {}
+
+            # Clear M2M junction tables first (before parent content tables)
+            for name, table in m2m_tables.items():
+                cursor.execute(f'DELETE FROM {table}')
+                deleted_counts[f'M2M:{name}'] = cursor.rowcount
+                self.stdout.write(f'  Cleared {cursor.rowcount:>8,} from M2M {name}')
+
+            # Delete from content tables (FK-dependency order)
+            for label, table, where in tables_to_delete:
+                sql = f'DELETE FROM {table}'
+                if where:
+                    sql += f' WHERE {where}'
+                cursor.execute(sql)
+                deleted_counts[label] = cursor.rowcount
+                self.stdout.write(f'  Deleted {cursor.rowcount:>8,} from {label}')
+
+            # Reset user profile fields
+            cursor.execute("""
+                UPDATE account_user SET
+                    persona = '{}',
+                    interests_updated_at = NULL,
+                    personas_updated_at = NULL,
+                    last_interest_card_category = NULL
+                WHERE is_superuser = FALSE AND deleted IS NULL
+            """)
+            profiles_reset = cursor.rowcount
+            self.stdout.write(f'  Reset   {profiles_reset:>8,} user profiles')
+
+        # --- Media file cleanup ---
+        self.stdout.write(self.style.MIGRATE_HEADING('\n--- Step 3: Media File Cleanup ---'))
+        media_root = getattr(settings, 'MEDIA_ROOT', None)
+        if media_root:
+            note_images_dir = os.path.join(media_root, 'note_images')
+            if os.path.isdir(note_images_dir):
+                shutil.rmtree(note_images_dir)
+                os.makedirs(note_images_dir, exist_ok=True)
+                self.stdout.write(f'  Cleared {note_images_dir}')
+            else:
+                self.stdout.write(f'  No note_images directory found at {note_images_dir}')
+        else:
+            self.stdout.write('  MEDIA_ROOT not configured, skipping media cleanup.')
+
+        # --- Summary ---
+        self.stdout.write(self.style.MIGRATE_HEADING('\n--- Summary ---'))
+        total_deleted = sum(v for v in deleted_counts.values())
+        self.stdout.write(f'  Total records deleted/cleared: {total_deleted:,}')
+        self.stdout.write(f'  User profiles reset: {profiles_reset}')
+        if backup_path:
+            self.stdout.write(f'  Backup file: {backup_path}')
+        self.stdout.write(self.style.SUCCESS('\nExperiment data reset complete.'))

--- a/adoorback/adoorback/management/commands/swap_versions.py
+++ b/adoorback/adoorback/management/commands/swap_versions.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
@@ -17,8 +18,27 @@ class Command(BaseCommand):
             '--user-ids', nargs='*', type=int,
             help='Only swap specific user IDs (default: all non-superusers).'
         )
+        parser.add_argument(
+            '--reset', action='store_true',
+            help='Reset all user content data before swapping versions. '
+                 'Takes a pg_dump backup first, then hard-deletes content.',
+        )
 
     def handle(self, *args, **options):
+        # Run experiment data reset before swapping if --reset is set
+        if options['reset']:
+            if options['dry_run']:
+                self.stdout.write(self.style.MIGRATE_HEADING(
+                    '--- Reset (dry-run): showing what would be deleted ---'
+                ))
+                call_command('reset_experiment_data', dry_run=True)
+            else:
+                self.stdout.write(self.style.MIGRATE_HEADING(
+                    '--- Resetting experiment data before version swap ---'
+                ))
+                call_command('reset_experiment_data', no_input=True)
+            self.stdout.write('')
+
         queryset = User.objects.exclude(is_superuser=True)
         if options['user_ids']:
             queryset = queryset.filter(id__in=options['user_ids'])

--- a/adoorback/adoorback/management/commands/tests_reset_experiment_data.py
+++ b/adoorback/adoorback/management/commands/tests_reset_experiment_data.py
@@ -1,0 +1,281 @@
+from io import StringIO
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.db import connection
+from django.test import TestCase, override_settings
+from django.contrib.auth import get_user_model
+
+from account.models import (
+    Connection, CustomChip, DiscoverFeed, FriendRequest,
+    Interest, Persona, Subscription,
+)
+from check_in.models import CheckIn, Song
+from comment.models import Comment
+from like.models import Like
+from note.models import Note
+from notification.models import Notification, NotificationActor
+from qna.models import Question, Response
+from reaction.models import Reaction
+
+User = get_user_model()
+
+
+class ResetExperimentDataCommandTests(TestCase):
+    """Test the reset_experiment_data management command."""
+
+    def setUp(self):
+        # Create users
+        self.user1 = User.objects.create_user(
+            username='alice', email='alice@test.com', password='password',
+            current_ver='version_w', user_group='group_w_first',
+            bio='Hello!', pronouns='she/her',
+            persona=['creative', 'adventurous'],
+        )
+        self.user2 = User.objects.create_user(
+            username='bob', email='bob@test.com', password='password',
+            current_ver='version_q', user_group='group_q_first',
+            bio='Hey!', pronouns='he/him',
+            persona=['analytical'],
+        )
+        self.admin = User.objects.create_superuser(
+            username='admin', email='admin@test.com', password='password',
+            persona=['admin_persona'],
+        )
+
+        # Create a connection (friendship) - should be preserved
+        self.connection = Connection.objects.create(
+            user1=self.user1, user2=self.user2,
+            user1_choice='close_friend', user2_choice='friend',
+        )
+
+        # Create an accepted friend request - should be preserved
+        self.accepted_fr = FriendRequest.objects.create(
+            requester=self.user1, requestee=self.user2, accepted=True,
+            requester_choice='close_friend', requestee_choice='friend',
+        )
+
+        # Create a pending friend request - should be deleted
+        self.user3 = User.objects.create_user(
+            username='carol', email='carol@test.com', password='password',
+        )
+        self.pending_fr = FriendRequest.objects.create(
+            requester=self.user1, requestee=self.user3, accepted=None,
+            requester_choice='friend',
+        )
+
+        # Create content: question (preserved) + response (deleted)
+        self.question = Question.objects.create(
+            author=self.admin, content='What is your favorite color?',
+            is_admin_question=True,
+        )
+        self.response = Response.objects.create(
+            author=self.user1, question=self.question, content='Blue!',
+        )
+
+        # Create a note (deleted)
+        self.note = Note.objects.create(
+            author=self.user1, content='My first note',
+        )
+
+        # Create a check-in (deleted)
+        self.check_in = CheckIn.objects.create(
+            user=self.user1, is_active=True, thought='Feeling good',
+        )
+
+        # Create a comment on the note (deleted)
+        note_ct = ContentType.objects.get_for_model(Note)
+        self.comment = Comment.objects.create(
+            author=self.user2, content='Nice note!',
+            content_type=note_ct, object_id=self.note.id,
+        )
+
+        # Create a like on the note (deleted)
+        self.like = Like.objects.create(
+            user=self.user2, content_type=note_ct, object_id=self.note.id,
+        )
+
+        # Create a reaction on the note (deleted)
+        self.reaction = Reaction.objects.create(
+            user=self.user2, emoji='😊',
+            content_type=note_ct, object_id=self.note.id,
+        )
+
+        # Create interests and link to user (M2M cleared, Interest rows preserved)
+        self.interest = Interest.objects.create(content='Gaming', category='hobbies_activities')
+        self.interest.users.add(self.user1)
+
+        # Create persona and link to user
+        self.persona_obj = Persona.objects.create(content='Creative')
+        self.persona_obj.users.add(self.user1)
+
+        # Create custom chip (deleted)
+        self.chip = CustomChip.objects.create(
+            user=self.user1, text='MyChip', category='hobbies_activities',
+        )
+
+        # Create subscription (deleted)
+        self.subscription = Subscription.objects.create(
+            subscriber=self.user2, subscribed_to=self.user1,
+            content_type=ContentType.objects.get_for_model(CheckIn),
+        )
+
+        # Add favorites and hidden (cleared)
+        self.user1.favorites.add(self.user2)
+        self.user1.hidden.add(self.user2)
+
+    def _run_command(self, *args, **kwargs):
+        out = StringIO()
+        kwargs.setdefault('stdout', out)
+        kwargs.setdefault('stderr', StringIO())
+        call_command('reset_experiment_data', *args, **kwargs)
+        return out.getvalue()
+
+    def test_dry_run_does_not_delete(self):
+        """Dry run should display counts but not modify any data."""
+        output = self._run_command('--dry-run')
+        self.assertIn('DRY RUN', output)
+
+        # Everything should still exist
+        self.assertEqual(Note.objects.count(), 1)
+        self.assertEqual(Response.objects.count(), 1)
+        self.assertEqual(Comment.objects.count(), 1)
+        self.assertEqual(Like.objects.count(), 1)
+        self.assertEqual(CheckIn.objects.count(), 1)
+
+    def test_content_is_deleted(self):
+        """All user content should be hard-deleted after reset."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.assertEqual(Note.objects.count(), 0)
+        self.assertEqual(Response.objects.count(), 0)
+        self.assertEqual(Comment.objects.count(), 0)
+        self.assertEqual(Like.objects.count(), 0)
+        self.assertEqual(Reaction.objects.count(), 0)
+        self.assertEqual(CheckIn.objects.count(), 0)
+        self.assertEqual(Subscription.objects.count(), 0)
+        self.assertEqual(CustomChip.objects.count(), 0)
+
+    def test_notifications_are_deleted(self):
+        """All notifications and notification actors should be deleted."""
+        # Notifications may have been created by signals during setUp
+        noti_count_before = Notification.objects.count()
+        actor_count_before = NotificationActor.objects.count()
+
+        self._run_command('--skip-backup', '--no-input')
+
+        self.assertEqual(Notification.objects.count(), 0)
+        self.assertEqual(NotificationActor.objects.count(), 0)
+
+    def test_connections_preserved(self):
+        """Friend connections should not be affected."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.assertTrue(Connection.objects.filter(
+            user1=self.user1, user2=self.user2
+        ).exists())
+        conn = Connection.objects.get(user1=self.user1, user2=self.user2)
+        self.assertEqual(conn.user1_choice, 'close_friend')
+        self.assertEqual(conn.user2_choice, 'friend')
+
+    def test_accepted_friend_request_preserved(self):
+        """Accepted friend requests should not be deleted."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.assertTrue(FriendRequest.objects.filter(
+            requester=self.user1, requestee=self.user2, accepted=True
+        ).exists())
+
+    def test_pending_friend_request_deleted(self):
+        """Pending friend requests (accepted=NULL) should be deleted."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.assertFalse(FriendRequest.objects.filter(
+            requester=self.user1, requestee=self.user3, accepted=None
+        ).exists())
+
+    def test_questions_preserved(self):
+        """Admin questions should not be deleted."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.assertTrue(Question.objects.filter(id=self.question.id).exists())
+
+    def test_user_accounts_preserved(self):
+        """User accounts with settings should remain intact."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.user1.refresh_from_db()
+        self.user2.refresh_from_db()
+        self.assertEqual(self.user1.username, 'alice')
+        self.assertEqual(self.user2.username, 'bob')
+        self.assertEqual(self.user1.email, 'alice@test.com')
+
+    def test_profile_bio_pronouns_preserved(self):
+        """Bio and pronouns should NOT be reset."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.bio, 'Hello!')
+        self.assertEqual(self.user1.pronouns, 'she/her')
+
+    def test_persona_field_reset(self):
+        """User persona array field should be cleared to empty."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.user1.refresh_from_db()
+        self.user2.refresh_from_db()
+        self.assertEqual(self.user1.persona, [])
+        self.assertEqual(self.user2.persona, [])
+
+    def test_admin_persona_not_reset(self):
+        """Superuser profile fields should not be touched."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.admin.refresh_from_db()
+        self.assertEqual(self.admin.persona, ['admin_persona'])
+
+    def test_interest_m2m_cleared(self):
+        """Interest-user associations should be cleared but Interest rows preserved."""
+        self._run_command('--skip-backup', '--no-input')
+
+        # Interest row still exists
+        self.assertTrue(Interest.objects.filter(content='Gaming').exists())
+        # But user association is gone
+        self.assertEqual(self.interest.users.count(), 0)
+
+    def test_persona_m2m_cleared(self):
+        """Persona-user associations should be cleared but Persona rows preserved."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.assertTrue(Persona.objects.filter(content='Creative').exists())
+        self.assertEqual(self.persona_obj.users.count(), 0)
+
+    def test_favorites_and_hidden_cleared(self):
+        """User favorites and hidden M2M should be cleared."""
+        self._run_command('--skip-backup', '--no-input')
+
+        self.user1.refresh_from_db()
+        self.assertEqual(self.user1.favorites.count(), 0)
+        self.assertEqual(self.user1.hidden.count(), 0)
+
+    def test_hard_delete_not_soft_delete(self):
+        """Records should be truly gone from the DB, not soft-deleted."""
+        self._run_command('--skip-backup', '--no-input')
+
+        # Use raw SQL to check even soft-deleted records
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT COUNT(*) FROM note_note')
+            self.assertEqual(cursor.fetchone()[0], 0)
+
+            cursor.execute('SELECT COUNT(*) FROM qna_response')
+            self.assertEqual(cursor.fetchone()[0], 0)
+
+            cursor.execute('SELECT COUNT(*) FROM comment_comment')
+            self.assertEqual(cursor.fetchone()[0], 0)
+
+    def test_output_shows_summary(self):
+        """Command output should include a summary."""
+        output = self._run_command('--skip-backup', '--no-input')
+
+        self.assertIn('Experiment data reset complete', output)
+        self.assertIn('Total records deleted/cleared', output)


### PR DESCRIPTION
# Experiment Phase Reset

Management command to reset user-generated content when swapping experiment versions (W/Q). Designed for the 4-week crossover study where each participant uses one version for 2 weeks, then switches.

## Quick Start: Version Swap Procedure

When it's time to switch versions (at the 2-week mark), SSH into the backend server and run:

```bash
# Step 1: Preview what will happen (safe, no changes made)
python manage.py reset_experiment_data --dry-run
python manage.py swap_versions --dry-run

# Step 2: Run the reset + swap together
python manage.py swap_versions --reset
```

This will:
1. Take a full `pg_dump` backup of the database
2. Prompt you to type `RESET` to confirm
3. Hard-delete all user content (notes, responses, check-ins, etc.)
4. Swap every user's `current_ver` between `version_w` and `version_q`
5. Set `ver_changed_at` to the current timestamp

### If running inside Docker

```bash
docker-compose -f docker-compose.development.yml exec web python manage.py swap_versions --reset
```

Or for production:

```bash
docker-compose exec web python manage.py swap_versions --reset
```

## What Gets Deleted

| Category | Models | Details |
|----------|--------|---------|
| Posts | Note, NoteImage | All notes and attached images |
| Q&A | Response, ResponseRequest | Responses to questions (Questions themselves are preserved) |
| Check-in | CheckIn, Song, Poke | Status updates, songs, pokes |
| Engagement | Comment, Like, Reaction | All interactions on content |
| Notifications | Notification, NotificationActor | All notification history |
| Discovery | DiscoverFeed, DiscoverFeedMusic, PlaylistFeed | Feed caches |
| Profile data | CustomChip, Interest-user links, Persona-user links | Chips deleted; Interest/Persona catalog rows kept, user associations cleared |
| User fields | `persona`, `interests_updated_at`, `personas_updated_at` | Reset to empty/null |
| Other | Subscription, UserTag, ContentReport | Subscriptions, mentions, content reports |
| Friend requests | FriendRequest (pending only) | Only `accepted IS NULL` rows are deleted |
| Favorites/Hidden | User.favorites, User.hidden M2M | Pinned/hidden friend lists cleared |

## What Is Preserved

| Category | Details |
|----------|---------|
| Friend connections | All `Connection` records including close_friend/friend level, upgrade times |
| Chat | ChatRoom, Message, MessageReaction, GroupReadCursor -- entire chat history |
| User accounts | Credentials, username, bio, profile image, pronouns, settings, language, timezone |
| Questions | Admin-created questions (reusable across phases) |
| Blocks | BlockRec, UserReport |
| Sessions | AppSession records |
| Accepted/rejected friend requests | Only pending (null) requests are removed |

## Commands

### `reset_experiment_data`

Standalone reset command. Can be run independently of version swap.

```bash
# Dry run -- show record counts, no changes
python manage.py reset_experiment_data --dry-run

# Full reset with backup
python manage.py reset_experiment_data

# Skip backup (local dev only)
python manage.py reset_experiment_data --skip-backup

# Non-interactive (for scripts, skips "type RESET" prompt)
python manage.py reset_experiment_data --no-input

# Custom backup directory
python manage.py reset_experiment_data --backup-dir /path/to/backups
```

### `swap_versions`

Existing version swap command, now with `--reset` flag.

```bash
# Swap only (no data reset)
python manage.py swap_versions

# Swap + reset (recommended for experiment phase change)
python manage.py swap_versions --reset

# Preview both reset and swap
python manage.py swap_versions --reset --dry-run

# Swap specific users only
python manage.py swap_versions --user-ids 1 2 3
```

When `--reset` is used, the reset runs **before** the swap so that `ver_changed_at` is set after the data is clean.

## Backup & Recovery

Every reset (unless `--skip-backup`) creates a `pg_dump` file:

```
backups/whoamitoday_pre_reset_20260509_140000.dump
```

To restore the backup into a separate database for analysis:

```bash
createdb whoamitoday_phase1
pg_restore -d whoamitoday_phase1 backups/whoamitoday_pre_reset_20260509_140000.dump
```

Note: The experiment logging system (`logs/experiment.log`) independently records all API actions in JSONL format, so behavioral data is always available regardless of the DB reset.

## Technical Details

- Uses **raw SQL** (`DELETE FROM`) instead of Django ORM to bypass SafeDelete soft-delete interception and Django signal dispatch (prevents Firebase push notifications firing during mass deletion)
- All deletions run in a **single database transaction** -- if any step fails, nothing is deleted
- M2M junction table names are resolved at **runtime** via Django's `Model.field.through._meta.db_table`
- Deletion order respects **FK dependencies**: junction tables first, then leaf nodes, then parent content tables
- Superuser accounts are excluded from profile field resets
