### PR TITLE
bugfix: #918 add chat error handling

### DIFF
--- a/adoorback/chat/views.py
+++ b/adoorback/chat/views.py
@@ -7,6 +7,7 @@ from rest_framework import generics, exceptions, status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 
+from adoorback.utils.alerts import send_msg_to_slack
 from adoorback.utils.validators import adoor_exception_handler
 from django.contrib.contenttypes.models import ContentType
 from .models import Message, ChatRoom, ChatRequest, MessageReaction, GroupReadCursor, MAX_GROUP_MEMBERS, get_or_create_chat_room, get_chat_room
@@ -181,10 +182,17 @@ class MessageList(generics.ListCreateAPIView):
         # Broadcast via WebSocket to the chat room
         group_name = _get_chat_group_name(user.id, connected_user.id)
         channel_layer = get_channel_layer()
-        async_to_sync(channel_layer.group_send)(
-            group_name,
-            {"type": "chat.message", "data": response.data},
-        )
+        try:
+            async_to_sync(channel_layer.group_send)(
+                group_name,
+                {"type": "chat.message", "data": response.data},
+            )
+        except Exception as e:
+            print(f"[CHAT BROADCAST ERROR] room={group_name}: {e}")
+            send_msg_to_slack(
+                text=f"*💬 Chat broadcast failed*\nRoom: `{group_name}`\nSender: {user.username} (ID: {user.id}) → Receiver: {connected_user.username} (ID: {connected_user.id})\n```{e}```",
+                level="ERROR",
+            )
 
         # Broadcast to both users' chat list so the list page updates
         print(f"[CHAT] Broadcasting chat list update for room between {user.id} and {connected_user.id}")


### PR DESCRIPTION
# Chat Message Send Failure: Silent Error Fix

## Problem

When two users are actively chatting (sending text, photos, etc.), one user's send button (paper airplane icon) suddenly stops working — pressing it does nothing. No error message, no toast, no visual feedback at all.

This bug existed before the recent block filter changes and occurs regardless of whether users have blocked each other.

## Root Cause

Two issues combine to produce the "nothing happens" symptom:

### 1. Backend: Unhandled WebSocket Broadcast Exception

In `MessageList.create()`, after the message is successfully saved to the database, the method broadcasts the new message via the channel layer (Redis in production). This broadcast had **no error handling**:

```python
# Before — no try/except
async_to_sync(channel_layer.group_send)(
    group_name,
    {"type": "chat.message", "data": response.data},
)
```

In production, if Redis is temporarily unavailable (connection timeout, memory pressure, brief restart), this line throws an unhandled exception. Because `super().create()` already committed the message to the database, the message **is saved** but the HTTP response becomes a **500 Internal Server Error**.

Note: This could not be reproduced locally because the development environment uses `InMemoryChannelLayer`, which never fails.

### 2. Frontend: Silent Error Swallowing

`ChatMessageInput.sendMessage()` caught all API errors with only `console.error`:

```typescript
// Before — silent catch
} catch (err) {
  console.error('[ChatMessageInput] send failed:', err);
}
```

Any error (403 Forbidden, 500 Internal Server Error, network failure) was logged to the browser console but **never shown to the user**. The input text remained, the send button stayed enabled, and from the user's perspective, pressing the button did absolutely nothing.

## Changes

### Backend

| File | What changed |
|------|-------------|
| `chat/views.py` | Wrapped the chat room WebSocket broadcast in `try/except`; on failure, logs the error and sends a Slack alert via `send_msg_to_slack()` |

The message is still saved and the 201 response is still returned to the client. Only the real-time WebSocket delivery to the chat room fails gracefully — the recipient will see the message on their next page load or scroll.

### Frontend

| File | What changed |
|------|-------------|
| `ChatMessageInput.tsx` | Replaced silent `console.error` with toast notifications: 403 → "send_blocked" message, other errors → "send_failed" message. Added `isSending` guard to prevent duplicate sends while a request is in flight. |
| `Chat.tsx` | Wrapped `fetchMessages` in `try/catch`; on 403 (e.g. blocked user), shows toast and navigates back instead of rendering an empty/broken chat page. |
| `i18n/locales/ko/translation.json` | Added `send_blocked` ("메시지를 보낼 수 없습니다.") and `send_failed` ("메시지 전송에 실패했습니다. 다시 시도해주세요.") |
| `i18n/locales/en/translation.json` | Added `send_blocked` ("This message could not be sent.") and `send_failed` ("Failed to send message. Please try again.") |

## Error Monitoring

The backend broadcast failure now triggers a Slack alert containing:
- Chat room identifier
- Sender and receiver usernames + IDs
- The exception message

Other chat errors (validation, authentication, CSRF) are already handled by the existing `adoor_exception_handler` which sends Slack alerts for server-level exceptions.

## Notes

- The `send_blocked` toast message is intentionally vague ("This message could not be sent.") rather than saying "You are blocked" — this follows the common UX pattern of not revealing block status to the blocked user.
- The `isSending` state prevents rapid double-taps from queuing duplicate API calls.
- The `fetchMessages` error handling in `Chat.tsx` also covers the case where a blocked user navigates directly to a chat URL — they see a toast and get redirected back instead of seeing a blank page.
