### PR TITLE
bugfix: #920 1-1 chat counter bug fix

### DIFF
--- a/adoorback/chat/views.py
+++ b/adoorback/chat/views.py
@@ -116,7 +116,25 @@ class MessageList(generics.ListCreateAPIView):
         paginated_queryset = self.paginator.paginate_queryset(self.get_queryset(), request)
         if paginated_queryset:
             msg_ids = [msg.id for msg in paginated_queryset]
-            Message.objects.filter(id__in=msg_ids, receiver=request.user, is_read=False).update(is_read=True)
+            marked = Message.objects.filter(id__in=msg_ids, receiver=request.user, is_read=False).update(is_read=True)
+            if marked > 0:
+                chat_room = get_chat_room(request.user, connected_user)
+                if chat_room:
+                    remaining = chat_room.messages.filter(receiver=request.user, is_read=False).count()
+                    channel_layer = get_channel_layer()
+                    try:
+                        async_to_sync(channel_layer.group_send)(
+                            f"user_{request.user.id}_chat_list",
+                            {
+                                "type": "chat.list.update",
+                                "data": {
+                                    "opponent_id": connected_user.id,
+                                    "unread_count": remaining,
+                                },
+                            },
+                        )
+                    except Exception:
+                        pass
 
         return response
 
@@ -235,6 +253,21 @@ class MarkMessagesRead(generics.GenericAPIView):
         chat_room = get_chat_room(user, connected_user)
         if chat_room:
             count = chat_room.messages.filter(receiver=user, is_read=False).update(is_read=True)
+            if count > 0:
+                channel_layer = get_channel_layer()
+                try:
+                    async_to_sync(channel_layer.group_send)(
+                        f"user_{user.id}_chat_list",
+                        {
+                            "type": "chat.list.update",
+                            "data": {
+                                "opponent_id": connected_user.id,
+                                "unread_count": 0,
+                            },
+                        },
+                    )
+                except Exception:
+                    pass
             return Response({'marked_read': count})
         return Response({'marked_read': 0})
 


### PR DESCRIPTION
# Fix: 1:1 Chat Unread Counter Stuck at 1

## Problem

In 1:1 chats, the unread message badge on the chat list always displayed "1" regardless of how many unread messages existed. Group chats were unaffected.

## Root Cause

Two interacting issues:

1. **Race condition in `Chat.tsx`**: Every incoming WebSocket message triggered `markMessagesRead()` immediately, marking all previous messages as read. When the next message was created, the backend counted only 1 unread message (the newest one).

2. **Missing broadcast on mark-read**: `MarkMessagesRead` and `MessageList.list` both marked messages as read but never broadcast the updated count to the chat list WebSocket. The badge retained its last stale value (always 1).

Group chats were unaffected because they use a cursor-based approach (`GroupReadCursor`) instead of per-message `is_read` flags.

## Changes

### Backend: `chat/views.py`

**`MarkMessagesRead.post()`** — After marking messages as read, broadcast `unread_count: 0` to the user's chat list WebSocket.

**`MessageList.list()`** — After marking paginated messages as read on page load, compute the remaining unread count and broadcast it to the user's chat list WebSocket.

### Frontend: `routes/chat/Chat.tsx`

**Debounce `markMessagesRead`** — Replaced the per-message `markMessagesRead()` call with a 300ms debounced version. Rapid consecutive messages now trigger a single API call, reducing the race condition window. Timer is cleaned up on unmount.

### Frontend: `routes/Root.tsx`

**Handle `unread_count: 0`** — Changed the condition from `data.unread_count > 0` to `typeof data.unread_count === 'number'` so that mark-read broadcasts (with count 0) also refresh the tab bar badge.
