### PR TITLE
Feat/issue 921

### DIFF
--- a/adoorback/chat/models.py
+++ b/adoorback/chat/models.py
@@ -240,15 +240,27 @@ def create_message_notification(created, instance, **kwargs):
     if receiver_user.id in sender.user_report_blocked_ids:
         return
 
+    # Determine notification text based on message type
+    if instance.image:
+        noti_ko = f"{sender.username}님이 사진을 보냈습니다!"
+        noti_en = f"{sender.username} sent you a photo!"
+    elif instance.shared_object_id:
+        noti_ko = f"{sender.username}님이 게시글을 보냈습니다!"
+        noti_en = f"{sender.username} sent you a post!"
+    else:
+        noti_ko = f"{sender.username}님이 메시지를 보냈습니다!"
+        noti_en = f"{sender.username} sent you a message!"
+
     recent_noti = Notification.objects.find_recent_message(receiver_user, sender)
 
     if recent_noti:
         current_count = 1
-        if "메시지를" in recent_noti.message_ko:
-            try:
-                current_count = int(recent_noti.message_ko.split("님이 ")[1].split("메시지를")[0][0])
-            except (IndexError, ValueError):
-                pass
+        try:
+            part = recent_noti.message_ko.split("님이 ")[1]
+            if "개의" in part:
+                current_count = int(part.split("개의")[0])
+        except (IndexError, ValueError):
+            pass
 
         new_count = current_count + 1
         recent_noti.message_ko = f"{sender.username}님이 {new_count}개의 메시지를 보냈습니다!"
@@ -262,8 +274,8 @@ def create_message_notification(created, instance, **kwargs):
             user=receiver_user,
             origin=sender,
             target=instance,
-            message_ko=f"{sender.username}님이 메시지를 보냈습니다!",
-            message_en=f"{sender.username} sent you a message!",
+            message_ko=noti_ko,
+            message_en=noti_en,
             redirect_url=f"/users/{sender.id}/chat",
         )
         NotificationActor.objects.create(user=sender, notification=noti)

--- a/adoorback/chat/serializers.py
+++ b/adoorback/chat/serializers.py
@@ -106,11 +106,36 @@ class ChatRoomSerializer(serializers.ModelSerializer):
 
     def get_last_message(self, obj):
         if hasattr(obj, 'last_message_content'):
-            return obj.last_message_content or obj.last_message_emoji
-        last_msg = obj.messages.last()
+            if obj.last_message_content:
+                return obj.last_message_content
+            if obj.last_message_emoji:
+                return obj.last_message_emoji
+            if obj.last_message_image:
+                return self._image_preview_text()
+            if obj.last_message_shared_type:
+                return self._shared_content_preview_text()
+            return None
+        last_msg = obj.messages.first()  # ordering=['-created_at'] so first=newest
         if last_msg:
-            return last_msg.content or last_msg.emoji
+            if last_msg.content:
+                return last_msg.content
+            if last_msg.emoji:
+                return last_msg.emoji
+            if last_msg.image:
+                return self._image_preview_text()
+            if last_msg.shared_object_id:
+                return self._shared_content_preview_text()
         return None
+
+    def _get_lang(self):
+        from django.utils.translation import get_language
+        return (get_language() or 'en')[:2]
+
+    def _image_preview_text(self):
+        return '📷 사진' if self._get_lang() == 'ko' else '📷 Photo'
+
+    def _shared_content_preview_text(self):
+        return '📎 공유된 게시글' if self._get_lang() == 'ko' else '📎 Shared post'
 
     def get_last_message_time(self, obj):
         if hasattr(obj, 'last_message_time'):

--- a/adoorback/chat/views.py
+++ b/adoorback/chat/views.py
@@ -25,6 +25,17 @@ def _get_chat_group_name(user_id_1, user_id_2):
     return f"chat_{ids[0]}_{ids[1]}"
 
 
+def _get_message_preview_text(response_data):
+    """Extract a preview string from serialized message data for chat list display."""
+    content = response_data.get('content') or response_data.get('emoji') or ''
+    if not content:
+        if response_data.get('image'):
+            content = '📷 Photo'
+        elif response_data.get('shared_content_preview'):
+            content = '📎 Shared post'
+    return content
+
+
 class ChatRoomList(generics.ListAPIView):
     serializer_class = ChatRoomSerializer
     permission_classes = [IsAuthenticated]
@@ -56,6 +67,8 @@ class ChatRoomList(generics.ListAPIView):
             last_message_time=Subquery(latest_msg.values('created_at')[:1]),
             last_message_content=Subquery(latest_msg.values('content')[:1]),
             last_message_emoji=Subquery(latest_msg.values('emoji')[:1]),
+            last_message_image=Subquery(latest_msg.values('image')[:1]),
+            last_message_shared_type=Subquery(latest_msg.values('shared_content_type')[:1]),
             unread_cnt=Count(
                 'messages',
                 filter=Q(messages__receiver=user, messages__is_read=False)
@@ -214,7 +227,7 @@ class MessageList(generics.ListCreateAPIView):
 
         # Broadcast to both users' chat list so the list page updates
         print(f"[CHAT] Broadcasting chat list update for room between {user.id} and {connected_user.id}")
-        content = response.data.get('content') or response.data.get('emoji') or ''
+        content = _get_message_preview_text(response.data)
         timestamp = response.data.get('created_at', '')
         receiver_unread = chat_room.messages.filter(receiver=connected_user, is_read=False).count()
         for target_user, unread in [(connected_user, receiver_unread), (user, 0)]:
@@ -701,7 +714,7 @@ class GroupMessageList(generics.ListCreateAPIView):
         )
 
         # Broadcast to all members' chat list (per-user unread count)
-        content = response.data.get('content') or response.data.get('emoji') or ''
+        content = _get_message_preview_text(response.data)
         timestamp = response.data.get('created_at', '')
         for member in room.members.exclude(id=request.user.id):
             cursor = GroupReadCursor.objects.filter(user=member, chat_room=room).first()


### PR DESCRIPTION
# Fix: Empty Preview for Image Messages

## Problem

When a user sends an image in chat, two things broke:

1. **Chat list** — the last message preview was blank instead of showing something like "Photo".
2. **Push notifications** — the notification said "sent you a message" with no indication it was an image.

## Root Cause

All preview/notification logic only checked `content` (text) and `emoji`, completely ignoring the `image` field. When a message contained only an image, every preview path returned an empty string.

## Changes

### Backend: `chat/views.py`

**`_get_message_preview_text()`** — New helper that returns a fallback preview string when `content` and `emoji` are both empty: `"📷 Photo"` for images, `"📎 Shared post"` for shared content.

**`ChatRoomList.get_queryset()`** — Added `last_message_image` and `last_message_shared_type` annotations so the serializer can detect non-text messages without an extra query.

**`MessageList.create()` / `GroupMessageList.create()`** — Replaced inline `content or emoji or ''` with the new helper, so WebSocket broadcasts to the chat list include proper preview text for images.

### Backend: `chat/serializers.py`

**`ChatRoomSerializer.get_last_message()`** — Extended to check `image` and `shared_content_type` after `content`/`emoji`. Returns locale-aware text (`"📷 사진"` for Korean, `"📷 Photo"` for English) via `django.utils.translation.get_language()`.

Also fixed a pre-existing bug: changed `obj.messages.last()` to `obj.messages.first()`. The default ordering is `-created_at`, so `.last()` was returning the oldest message instead of the newest.

### Backend: `chat/models.py`

**`create_message_notification()`** — Notification text now varies by message type:

| Type | Korean | English |
|------|--------|---------|
| Image | `{user}님이 사진을 보냈습니다!` | `{user} sent you a photo!` |
| Shared post | `{user}님이 게시글을 보냈습니다!` | `{user} sent you a post!` |
| Text (default) | `{user}님이 메시지를 보냈습니다!` | `{user} sent you a message!` |

Also fixed the grouped-notification count parser: the old code (`[0][0]`) only extracted single-digit counts. Replaced with `split("개의")[0]` to support 10+ grouped messages.
