### PR TITLE
feat(view-as): Phase 1 — shadow-viewer profile masking + wit_bot public proxy

### DIFF
--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -431,12 +431,17 @@ class UserProfileSerializer(UserMinimalSerializer):
         ret = super().to_representation(instance)
         request = self.context.get('request')
         user = request.user if request else None
+        view_as = self.context.get('view_as')
 
         # Check if the requester should see private fields
         can_see_private = False
         if user and user.is_authenticated:
-             if user == instance or user.is_connected(instance):
-                 can_see_private = True
+            if view_as is not None and user == instance:
+                # Owner is previewing as a specific audience tier:
+                # 'public' is treated as a non-friend; 'friends' and 'close_friends' are friends.
+                can_see_private = view_as in ('friends', 'close_friends')
+            elif user == instance or user.is_connected(instance):
+                can_see_private = True
 
         if not can_see_private:
             hidden_categories = {

--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -297,13 +297,27 @@ class UserProfileSerializer(UserMinimalSerializer):
     is_check_in_subscribed = serializers.SerializerMethodField(read_only=True)
     is_subscribed = serializers.SerializerMethodField(read_only=True)
 
-    def get_is_check_in_subscribed(self, obj):
+    def _get_viewer(self):
+        """Return the effective viewer for this serialization pass.
+
+        When `shadow_viewer` is set in context (View As feature), use it.
+        Otherwise fall back to the actual request user.
+        """
+        shadow = self.context.get('shadow_viewer')
+        if shadow is not None:
+            return shadow
         request = self.context.get('request')
-        if request and request.user.is_authenticated and request.user.current_ver == 'version_w':
+        if request is None or not request.user.is_authenticated:
+            return None
+        return request.user
+
+    def get_is_check_in_subscribed(self, obj):
+        viewer = self._get_viewer()
+        if viewer is not None and viewer.current_ver == 'version_w':
             from adoorback.utils.content_types import get_check_in_type
             from account.models import Subscription
             return Subscription.objects.filter(
-                subscriber=request.user, subscribed_to=obj, content_type=get_check_in_type()
+                subscriber=viewer, subscribed_to=obj, content_type=get_check_in_type()
             ).exists()
         return False
 
@@ -317,24 +331,24 @@ class UserProfileSerializer(UserMinimalSerializer):
         return False
 
     def get_is_favorite(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            return obj in request.user.favorites.all()
+        viewer = self._get_viewer()
+        if viewer is not None:
+            return obj in viewer.favorites.all()
         return False
 
     def get_check_in(self, obj):
-        user = self.context.get('request', None).user
+        viewer = self._get_viewer()
         check_in = obj.check_in_set.filter(is_active=True).first()
-        if check_in and CheckIn.is_audience(check_in, user):
+        if check_in and viewer is not None and CheckIn.is_audience(check_in, viewer):
             return serialize_check_in_base_for_viewer(
                 check_in, self.context.get('request'), self.context
             )
         return {}
 
     def get_mutuals(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            current_user_connections = set(request.user.connected_user_ids)
+        viewer = self._get_viewer()
+        if viewer is not None:
+            current_user_connections = set(viewer.connected_user_ids)
             obj_user_connections = set(obj.connected_user_ids)
 
             mutual_connections = current_user_connections & obj_user_connections
@@ -343,82 +357,95 @@ class UserProfileSerializer(UserMinimalSerializer):
         return {}
 
     def get_mutual_personas(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            current_user_personas = set(request.user.user_personas.all())
+        viewer = self._get_viewer()
+        if viewer is not None:
+            current_user_personas = set(viewer.user_personas.all())
             obj_personas = set(obj.user_personas.all())
             mutual_personas = current_user_personas & obj_personas
             return PersonaSerializer(mutual_personas, many=True).data
         return []
 
     def get_mutual_interests(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            current_user_interests = set(request.user.user_interests.all())
+        viewer = self._get_viewer()
+        if viewer is not None:
+            current_user_interests = set(viewer.user_interests.all())
             obj_interests = set(obj.user_interests.all())
             mutual_interests = current_user_interests & obj_interests
             return InterestSerializer(mutual_interests, many=True).data
         return []
 
     def get_are_friends(self, obj):  # does not mean 'friend' in friend & close friend, it means connection
-        user = self.context.get('request', None).user
-        if user == obj:
+        viewer = self._get_viewer()
+        if viewer is None:
+            return None
+        if viewer == obj:
             return None
         # WIT-Admin operators are admins of the support channel; for THEIR view,
         # treat every regular user as already-connected so the chat-request
         # gating UX doesn't fire on the operator side. Regular users' view of
         # operators is unchanged (no asymmetric leak in the user-facing UI).
         from chat.wit_admin import ALL_OPERATOR_EMAILS
-        if user.email in ALL_OPERATOR_EMAILS:
+        if viewer.email in ALL_OPERATOR_EMAILS:
             return True
-        return user.is_connected(obj)
+        return viewer.is_connected(obj)
 
     def get_connection_status(self, obj):  # what user has set obj as
-        user = self.context.get('request', None).user
-        if user == obj:
+        viewer = self._get_viewer()
+        if viewer is None:
             return None
-        if user.is_connected(obj):
-            if obj.is_close_friend(user):
+        if viewer == obj:
+            return None
+        if viewer.is_connected(obj):
+            if obj.is_close_friend(viewer):
                 return 'close_friend'
-            if obj.is_friend(user):
+            if obj.is_friend(viewer):
                 return 'friend'
         return None
 
     def get_received_friend_request_from(self, obj):
-        user = self.context.get('request').user
-        return user.id in obj.sent_friend_requests.filter(accepted__isnull=True).values_list('requestee_id', flat=True)
+        viewer = self._get_viewer()
+        if viewer is None:
+            return False
+        return viewer.id in obj.sent_friend_requests.filter(accepted__isnull=True).values_list('requestee_id', flat=True)
 
     def get_sent_friend_request_to(self, obj):
-        user = self.context.get('request').user
-        return user.id in obj.received_friend_requests.exclude(accepted=True).values_list('requester_id', flat=True)
+        viewer = self._get_viewer()
+        if viewer is None:
+            return False
+        return viewer.id in obj.received_friend_requests.exclude(accepted=True).values_list('requester_id', flat=True)
 
     def get_sent_chat_request_to(self, obj):
-        user = self.context.get('request').user
-        return obj.received_chat_requests.filter(requester=user, accepted__isnull=True).exists()
+        viewer = self._get_viewer()
+        if viewer is None:
+            return False
+        return obj.received_chat_requests.filter(requester=viewer, accepted__isnull=True).exists()
 
     def get_received_chat_request_from(self, obj):
-        user = self.context.get('request').user
-        req = obj.sent_chat_requests.filter(requestee=user, accepted__isnull=True).first()
+        viewer = self._get_viewer()
+        if viewer is None:
+            return None
+        req = obj.sent_chat_requests.filter(requestee=viewer, accepted__isnull=True).first()
         return req.id if req else None
 
     def get_unread_chat_count(self, obj):
-        request = self.context.get('request')
-        if request and request.user.is_authenticated:
-            user = request.user
-            if user == obj:
+        viewer = self._get_viewer()
+        if viewer is not None:
+            if viewer == obj:
                 return 0
-            chat_room = get_chat_room(user, obj)
+            chat_room = get_chat_room(viewer, obj)
             if chat_room:
-                return chat_room.messages.filter(receiver=user, is_read=False).count()
+                return chat_room.messages.filter(receiver=viewer, is_read=False).count()
         return 0
-    
+
     def get_friendship_level(self, obj):
-        user = self.context.get('request', None).user
-        if user == obj:
+        viewer = self._get_viewer()
+        if viewer is None:
+            return '3rd+'
+        if viewer == obj:
             return None
-        if user.is_connected(obj):
+        if viewer.is_connected(obj):
             return '1st'
-        current_user_connections = set(user.connected_user_ids)
+        current_user_connections = set(viewer.connected_user_ids)
         obj_connections = set(obj.connected_user_ids)
         if current_user_connections & obj_connections:
             return '2nd'
@@ -429,15 +456,16 @@ class UserProfileSerializer(UserMinimalSerializer):
 
     def to_representation(self, instance):
         ret = super().to_representation(instance)
-        request = self.context.get('request')
-        user = request.user if request else None
+        user = self._get_viewer()
         view_as = self.context.get('view_as')
 
         # Check if the requester should see private fields
         can_see_private = False
-        if user and user.is_authenticated:
-            if view_as is not None and user == instance:
-                # Owner is previewing as a specific audience tier:
+        if user is not None:
+            request = self.context.get('request')
+            actual_requester = request.user if request else None
+            if view_as is not None and actual_requester == instance and self.context.get('shadow_viewer') is None:
+                # Owner is previewing as a specific audience tier (no shadow viewer set):
                 # 'public' is treated as a non-friend; 'friends' and 'close_friends' are friends.
                 can_see_private = view_as in ('friends', 'close_friends')
             elif user == instance or user.is_connected(instance):

--- a/adoorback/account/tests_view_as.py
+++ b/adoorback/account/tests_view_as.py
@@ -63,3 +63,34 @@ class ProfileViewAsTests(TestCase):
     def test_view_as_invalid_returns_400(self):
         response = self.client.get('/api/user/me/profile/?view_as=enemies')
         self.assertEqual(response.status_code, 400)
+
+    def test_view_as_public_hides_friends_only_persona(self):
+        """When online_persona_friends_only=True, public view sees empty personas."""
+        self.owner.online_persona_friends_only = True
+        self.owner.save()
+
+        response = self.client.get('/api/user/me/profile/?view_as=public')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get('user_personas'), [])
+
+    def test_view_as_friends_includes_persona(self):
+        """When online_persona_friends_only=True, friends view still sees personas."""
+        self.owner.online_persona_friends_only = True
+        self.owner.save()
+
+        response = self.client.get('/api/user/me/profile/?view_as=friends')
+        self.assertEqual(response.status_code, 200)
+        # Friends are treated as can_see_private; user_personas isn't blanked.
+        # We're not asserting any specific personas (none created), just that
+        # the field is not forced to []. (Without view_as=friends, the field
+        # would also not be blanked, so this test pins down the behavior.)
+        self.assertIsNotNone(response.data.get('user_personas'))
+
+    def test_view_as_close_friends_includes_persona(self):
+        """When online_persona_friends_only=True, close_friends view sees personas."""
+        self.owner.online_persona_friends_only = True
+        self.owner.save()
+
+        response = self.client.get('/api/user/me/profile/?view_as=close_friends')
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(response.data.get('user_personas'))

--- a/adoorback/account/tests_view_as.py
+++ b/adoorback/account/tests_view_as.py
@@ -1,0 +1,22 @@
+from django.test import RequestFactory, TestCase
+from rest_framework.exceptions import ValidationError
+from account.view_as import parse_view_as, VIEW_AS_TIERS
+
+
+class ParseViewAsTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_returns_none_when_param_missing(self):
+        request = self.factory.get('/api/user/me/')
+        self.assertIsNone(parse_view_as(request))
+
+    def test_returns_tier_when_valid(self):
+        for tier in VIEW_AS_TIERS:
+            request = self.factory.get(f'/api/user/me/?view_as={tier}')
+            self.assertEqual(parse_view_as(request), tier)
+
+    def test_raises_validation_error_when_invalid(self):
+        request = self.factory.get('/api/user/me/?view_as=enemies')
+        with self.assertRaises(ValidationError):
+            parse_view_as(request)

--- a/adoorback/account/tests_view_as.py
+++ b/adoorback/account/tests_view_as.py
@@ -261,3 +261,93 @@ class ShadowViewerProfileTests(TestCase):
         self.assertEqual(response.status_code, 200)
         # The response is from stranger's perspective, NOT alice's. So bio (friends_only) is hidden.
         self.assertIn(response.data.get('bio'), (None, ''))
+
+
+class PublicProxyViewerTests(TestCase):
+    """Tests for the public-proxy resolution: ?view_as=public uses wit_bot as shadow viewer."""
+
+    def setUp(self):
+        from account.models import Connection
+        self.owner = User.objects.create_user(
+            username='owner_pp', email='owner_pp@example.com', password='pw',
+        )
+        self.owner.bio = 'Owner bio'
+        self.owner.bio_friends_only = True
+        self.owner.save()
+        self.proxy = User.objects.create_user(
+            username='wit_bot', email='wit_bot@example.com', password='pw',
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.owner)
+
+    def test_view_as_public_uses_wit_bot_as_shadow_viewer(self):
+        """When the proxy exists and isn't a friend, ?view_as=public renders from its perspective."""
+        response = self.client.get('/api/user/me/profile/?view_as=public')
+        self.assertEqual(response.status_code, 200)
+        # bio is friends_only and proxy is not a friend → bio should be hidden
+        self.assertIn(response.data.get('bio'), (None, ''))
+        # are_friends should reflect proxy<->owner relationship (false)
+        self.assertFalse(response.data.get('are_friends', True))
+
+    def test_view_as_public_falls_back_when_proxy_does_not_exist(self):
+        """If proxy user doesn't exist, fall back to tier-mode masking."""
+        self.proxy.delete()
+        response = self.client.get('/api/user/me/profile/?view_as=public')
+        self.assertEqual(response.status_code, 200)
+        # Tier-mode masking still hides bio
+        self.assertIn(response.data.get('bio'), (None, ''))
+
+    def test_view_as_public_falls_back_when_proxy_is_friend(self):
+        """If proxy user has somehow become a friend of owner, fall back to tier-mode."""
+        from account.models import Connection
+        Connection.objects.create(
+            user1=self.owner, user2=self.proxy,
+            user1_choice='friend', user2_choice='friend',
+        )
+        response = self.client.get('/api/user/me/profile/?view_as=public')
+        self.assertEqual(response.status_code, 200)
+        # bio is still hidden (tier-mode), but the rendering is no longer "from proxy's perspective"
+        self.assertIn(response.data.get('bio'), (None, ''))
+
+
+class ResolvePublicProxyViewerUnitTests(TestCase):
+    """Direct unit tests for resolve_public_proxy_viewer."""
+
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username='unit_owner', email='unit_owner@example.com', password='pw',
+        )
+
+    def test_returns_none_when_proxy_missing(self):
+        from account.view_as import resolve_public_proxy_viewer
+        # Don't create the proxy user
+        self.assertIsNone(resolve_public_proxy_viewer(self.owner))
+
+    def test_returns_proxy_when_present_and_not_friend(self):
+        from account.view_as import resolve_public_proxy_viewer
+        proxy = User.objects.create_user(
+            username='wit_bot', email='wit_bot_unit@example.com', password='pw',
+        )
+        result = resolve_public_proxy_viewer(self.owner)
+        self.assertEqual(result, proxy)
+
+    def test_returns_none_when_proxy_is_friend(self):
+        from account.view_as import resolve_public_proxy_viewer
+        from account.models import Connection
+        proxy = User.objects.create_user(
+            username='wit_bot', email='wit_bot_unit2@example.com', password='pw',
+        )
+        Connection.objects.create(
+            user1=self.owner, user2=proxy,
+            user1_choice='friend', user2_choice='friend',
+        )
+        self.assertIsNone(resolve_public_proxy_viewer(self.owner))
+
+    def test_returns_none_when_proxy_is_owner(self):
+        """Edge case: if the proxy username happens to match the owner's, return None."""
+        from account.view_as import resolve_public_proxy_viewer
+        # Create a user whose username is the proxy's
+        weird_owner = User.objects.create_user(
+            username='wit_bot', email='wit_bot_owner@example.com', password='pw',
+        )
+        self.assertIsNone(resolve_public_proxy_viewer(weird_owner))

--- a/adoorback/account/tests_view_as.py
+++ b/adoorback/account/tests_view_as.py
@@ -1,6 +1,6 @@
 from django.test import RequestFactory, TestCase
 from rest_framework.exceptions import ValidationError
-from rest_framework.test import APIClient
+from rest_framework.test import APIClient, APIRequestFactory
 from account.models import User
 from account.view_as import parse_view_as, VIEW_AS_TIERS
 
@@ -112,3 +112,82 @@ class ProfileViewAsTests(TestCase):
         # bio is friends_only and `other` is not a friend → bio must be hidden
         # regardless of view_as=close_friends
         self.assertIn(response.data.get('bio'), (None, ''))
+
+
+class ParseViewAsUserTests(TestCase):
+    """Tests for the parse_view_as_user query-param parser."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_returns_none_when_param_missing(self):
+        from account.view_as import parse_view_as_user
+        request = self.factory.get('/api/user/me/profile/')
+        self.assertIsNone(parse_view_as_user(request))
+
+    def test_returns_username_when_present(self):
+        from account.view_as import parse_view_as_user
+        request = self.factory.get('/api/user/me/profile/?view_as_user=alice')
+        self.assertEqual(parse_view_as_user(request), 'alice')
+
+    def test_returns_none_when_empty_string(self):
+        from account.view_as import parse_view_as_user
+        request = self.factory.get('/api/user/me/profile/?view_as_user=')
+        self.assertIsNone(parse_view_as_user(request))
+
+
+class ResolveShadowViewerTests(TestCase):
+    """Tests for the resolve_shadow_viewer helper.
+
+    The helper takes a request, the target profile owner, and returns either
+    a User instance to use as the effective viewer OR None if the param is
+    missing / unauthorized / invalid.
+
+    Owner-only: only the target's owner is allowed to use shadow_viewer.
+    """
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.owner = User.objects.create_user(
+            username='owner', email='owner@example.com', password='pw',
+        )
+        self.alice = User.objects.create_user(
+            username='alice', email='alice@example.com', password='pw',
+        )
+        self.bob = User.objects.create_user(
+            username='bob', email='bob@example.com', password='pw',
+        )
+
+    def test_returns_none_when_param_missing(self):
+        from account.view_as import resolve_shadow_viewer
+        request = self.factory.get('/api/user/me/profile/')
+        request.user = self.owner
+        self.assertIsNone(resolve_shadow_viewer(request, self.owner))
+
+    def test_returns_user_when_owner_requests_valid_username(self):
+        from account.view_as import resolve_shadow_viewer
+        request = self.factory.get('/api/user/me/profile/?view_as_user=alice')
+        request.user = self.owner
+        result = resolve_shadow_viewer(request, self.owner)
+        self.assertEqual(result, self.alice)
+
+    def test_returns_none_when_non_owner_tries(self):
+        """A non-owner sending view_as_user is ignored (not an abuse vector)."""
+        from account.view_as import resolve_shadow_viewer
+        request = self.factory.get('/api/user/owner/profile/?view_as_user=alice')
+        request.user = self.bob  # not the owner
+        self.assertIsNone(resolve_shadow_viewer(request, self.owner))
+
+    def test_returns_none_when_username_does_not_exist(self):
+        from account.view_as import resolve_shadow_viewer
+        request = self.factory.get('/api/user/me/profile/?view_as_user=nonexistent')
+        request.user = self.owner
+        self.assertIsNone(resolve_shadow_viewer(request, self.owner))
+
+    def test_returns_none_when_owner_picks_themselves(self):
+        """Owner picking themselves as shadow viewer is a no-op (treat as unset)."""
+        from account.view_as import resolve_shadow_viewer
+        request = self.factory.get('/api/user/me/profile/?view_as_user=owner')
+        request.user = self.owner
+        # Owner viewing their own profile through their own eyes is identity → no shadow
+        self.assertIsNone(resolve_shadow_viewer(request, self.owner))

--- a/adoorback/account/tests_view_as.py
+++ b/adoorback/account/tests_view_as.py
@@ -94,3 +94,21 @@ class ProfileViewAsTests(TestCase):
         response = self.client.get('/api/user/me/profile/?view_as=close_friends')
         self.assertEqual(response.status_code, 200)
         self.assertIsNotNone(response.data.get('user_personas'))
+
+    def test_non_owner_cannot_use_view_as_to_mask_someone_else_profile(self):
+        """Non-owner sending view_as on someone else's profile sees the friend-view filtered.
+
+        The owner has bio_friends_only=True. `other` is unrelated to owner (no Connection).
+        Even when `other` sends view_as=close_friends (trying to coerce a higher tier than
+        they actually have), the response should still hide the bio because the masking
+        helper and serializer gate on `user == instance` — view_as is a no-op for non-owners.
+        """
+        other = User.objects.create_user(
+            username='other', email='other@example.com', password='pw',
+        )
+        self.client.force_authenticate(user=other)
+        response = self.client.get(f'/api/user/{self.owner.username}/profile/?view_as=close_friends')
+        self.assertEqual(response.status_code, 200)
+        # bio is friends_only and `other` is not a friend → bio must be hidden
+        # regardless of view_as=close_friends
+        self.assertIn(response.data.get('bio'), (None, ''))

--- a/adoorback/account/tests_view_as.py
+++ b/adoorback/account/tests_view_as.py
@@ -1,5 +1,7 @@
 from django.test import RequestFactory, TestCase
 from rest_framework.exceptions import ValidationError
+from rest_framework.test import APIClient
+from account.models import User
 from account.view_as import parse_view_as, VIEW_AS_TIERS
 
 
@@ -20,3 +22,44 @@ class ParseViewAsTests(TestCase):
         request = self.factory.get('/api/user/me/?view_as=enemies')
         with self.assertRaises(ValidationError):
             parse_view_as(request)
+
+
+class ProfileViewAsTests(TestCase):
+    def setUp(self):
+        self.owner = User.objects.create_user(
+            username='owner', email='owner@example.com', password='pw',
+        )
+        self.owner.bio = 'Hi, I am the owner.'
+        self.owner.bio_friends_only = True
+        self.owner.pronouns = 'they/them'
+        self.owner.pronouns_friends_only = True
+        self.owner.save()
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.owner)
+
+    def test_owner_without_view_as_sees_full_bio(self):
+        response = self.client.get('/api/user/me/profile/')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get('bio'), 'Hi, I am the owner.')
+        self.assertEqual(response.data.get('pronouns'), 'they/them')
+
+    def test_view_as_public_masks_bio_when_friends_only(self):
+        response = self.client.get('/api/user/me/profile/?view_as=public')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(response.data.get('bio'), (None, ''))
+        self.assertIn(response.data.get('pronouns'), (None, ''))
+
+    def test_view_as_friends_keeps_bio_visible(self):
+        response = self.client.get('/api/user/me/profile/?view_as=friends')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get('bio'), 'Hi, I am the owner.')
+        self.assertEqual(response.data.get('pronouns'), 'they/them')
+
+    def test_view_as_close_friends_keeps_bio_visible(self):
+        response = self.client.get('/api/user/me/profile/?view_as=close_friends')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get('bio'), 'Hi, I am the owner.')
+
+    def test_view_as_invalid_returns_400(self):
+        response = self.client.get('/api/user/me/profile/?view_as=enemies')
+        self.assertEqual(response.status_code, 400)

--- a/adoorback/account/tests_view_as.py
+++ b/adoorback/account/tests_view_as.py
@@ -191,3 +191,73 @@ class ResolveShadowViewerTests(TestCase):
         request.user = self.owner
         # Owner viewing their own profile through their own eyes is identity → no shadow
         self.assertIsNone(resolve_shadow_viewer(request, self.owner))
+
+
+class ShadowViewerProfileTests(TestCase):
+    """Integration tests: ?view_as_user=<username> behaves as if that user were the viewer.
+
+    The owner has `bio_friends_only=True`. When the owner previews their profile
+    AS alice (a friend), bio is visible (alice is a friend → can see). When the
+    owner previews AS a non-friend (synthetic public stranger), bio is hidden.
+    """
+
+    def setUp(self):
+        from account.models import Connection
+        self.owner = User.objects.create_user(
+            username='owner_sv', email='owner_sv@example.com', password='pw',
+        )
+        self.owner.bio = 'Hi, I am the owner.'
+        self.owner.bio_friends_only = True
+        self.owner.save()
+
+        self.alice = User.objects.create_user(
+            username='alice_sv', email='alice_sv@example.com', password='pw',
+        )
+        # alice is friends with owner
+        Connection.objects.create(
+            user1=self.owner, user2=self.alice,
+            user1_choice='friend', user2_choice='friend',
+        )
+
+        self.stranger = User.objects.create_user(
+            username='stranger_sv', email='stranger_sv@example.com', password='pw',
+        )
+        # No connection with owner
+
+        self.client = APIClient()
+
+    def test_owner_views_as_friend_sees_bio(self):
+        """Owner previews as alice (friend) → bio is visible because alice can see it."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get('/api/user/me/profile/?view_as_user=alice_sv')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data.get('bio'), 'Hi, I am the owner.')
+
+    def test_owner_views_as_stranger_hides_bio(self):
+        """Owner previews as stranger (no connection) → bio is hidden."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get('/api/user/me/profile/?view_as_user=stranger_sv')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(response.data.get('bio'), (None, ''))
+
+    def test_owner_views_as_returns_friendship_derived_fields_from_shadow_perspective(self):
+        """Friend-status fields reflect the shadow viewer's relationship, not the owner's."""
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get('/api/user/me/profile/?view_as_user=alice_sv')
+        self.assertEqual(response.status_code, 200)
+        # are_friends should reflect the alice<->owner relationship (true), not owner<->owner (n/a)
+        self.assertTrue(response.data.get('are_friends', False))
+
+    def test_owner_views_as_stranger_returns_not_friends(self):
+        self.client.force_authenticate(user=self.owner)
+        response = self.client.get('/api/user/me/profile/?view_as_user=stranger_sv')
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(response.data.get('are_friends', True))
+
+    def test_non_owner_view_as_user_is_silently_ignored(self):
+        """Non-owner sending view_as_user is ignored (returns response based on actual viewer)."""
+        self.client.force_authenticate(user=self.stranger)
+        response = self.client.get(f'/api/user/{self.owner.username}/profile/?view_as_user=alice_sv')
+        self.assertEqual(response.status_code, 200)
+        # The response is from stranger's perspective, NOT alice's. So bio (friends_only) is hidden.
+        self.assertIn(response.data.get('bio'), (None, ''))

--- a/adoorback/account/view_as.py
+++ b/adoorback/account/view_as.py
@@ -84,3 +84,38 @@ def resolve_shadow_viewer(request, target_owner):
     if candidate == target_owner:
         return None
     return candidate
+
+
+# Username of the user that stands in as the "public non-friend" viewer for
+# View As preview (when ?view_as=public is sent). Configurable via
+# settings.VIEW_AS_PUBLIC_PROXY_USERNAME if defined; otherwise defaults below.
+DEFAULT_NON_FRIEND_PROXY_USERNAME = 'wit_bot'
+
+
+def _get_proxy_username() -> str:
+    from django.conf import settings
+    return getattr(settings, 'VIEW_AS_PUBLIC_PROXY_USERNAME', DEFAULT_NON_FRIEND_PROXY_USERNAME)
+
+
+def resolve_public_proxy_viewer(target_owner):
+    """Resolve the configured non-friend proxy user for `?view_as=public`.
+
+    Returns the proxy User instance only when:
+      - The proxy user exists
+      - The proxy user is NOT the owner themselves
+      - The proxy user is NOT connected to the owner (must actually be a non-friend
+        for the preview to be representative of the public non-friend view)
+
+    Returns None if any of the above fails. Callers should fall back to the
+    existing tier-mode masking (via apply_profile_view_as) when None is returned.
+    """
+    User = get_user_model()
+    try:
+        proxy = User.objects.get(username=_get_proxy_username())
+    except User.DoesNotExist:
+        return None
+    if proxy == target_owner:
+        return None
+    if target_owner.is_connected(proxy):
+        return None
+    return proxy

--- a/adoorback/account/view_as.py
+++ b/adoorback/account/view_as.py
@@ -1,4 +1,5 @@
 from typing import Dict, Optional
+from django.contrib.auth import get_user_model
 from rest_framework.exceptions import ValidationError
 
 VIEW_AS_TIERS = ('public', 'friends', 'close_friends')
@@ -39,3 +40,47 @@ def apply_profile_view_as(data: dict, owner, tier: Optional[str]) -> dict:
         if getattr(owner, flag, False) and field in data:
             data[field] = None
     return data
+
+
+def parse_view_as_user(request) -> Optional[str]:
+    """Parse the `view_as_user` query param.
+
+    Returns the username string if present, None if missing or empty.
+    Does NOT validate that the user exists — that's resolve_shadow_viewer's job.
+    """
+    raw = (
+        request.query_params.get('view_as_user')
+        if hasattr(request, 'query_params')
+        else request.GET.get('view_as_user')
+    )
+    if raw is None or raw == '':
+        return None
+    return raw
+
+
+def resolve_shadow_viewer(request, target_owner):
+    """Resolve `?view_as_user=<username>` to a User instance for shadow-viewer mode.
+
+    Returns the chosen User instance only when:
+      - The query param is present
+      - The requester is the target profile's owner (gate against abuse)
+      - The chosen user exists
+      - The chosen user is NOT the owner themselves (no-op, return None)
+
+    Returns None in all other cases. Callers should fall back to `request.user`.
+    """
+    username = parse_view_as_user(request)
+    if username is None:
+        return None
+    # Owner-only gate: only the owner of the target profile may use shadow viewer.
+    if request.user != target_owner:
+        return None
+    User = get_user_model()
+    try:
+        candidate = User.objects.get(username=username)
+    except User.DoesNotExist:
+        return None
+    # Picking yourself as shadow viewer is identity → return None to fall back.
+    if candidate == target_owner:
+        return None
+    return candidate

--- a/adoorback/account/view_as.py
+++ b/adoorback/account/view_as.py
@@ -1,0 +1,18 @@
+from typing import Optional
+from rest_framework.exceptions import ValidationError
+
+VIEW_AS_TIERS = ('public', 'friends', 'close_friends')
+
+
+def parse_view_as(request) -> Optional[str]:
+    """Parse the `view_as` query param.
+
+    Returns None if missing. Raises ValidationError(400) if present but
+    not one of VIEW_AS_TIERS.
+    """
+    raw = request.query_params.get('view_as') if hasattr(request, 'query_params') else request.GET.get('view_as')
+    if raw is None or raw == '':
+        return None
+    if raw not in VIEW_AS_TIERS:
+        raise ValidationError({'view_as': f"Must be one of {VIEW_AS_TIERS}."})
+    return raw

--- a/adoorback/account/view_as.py
+++ b/adoorback/account/view_as.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Dict, Optional
 from rest_framework.exceptions import ValidationError
 
 VIEW_AS_TIERS = ('public', 'friends', 'close_friends')
@@ -16,3 +16,26 @@ def parse_view_as(request) -> Optional[str]:
     if raw not in VIEW_AS_TIERS:
         raise ValidationError({'view_as': f"Must be one of {VIEW_AS_TIERS}."})
     return raw
+
+
+# Map of profile field name → friends_only flag name.
+# Public viewer has the field hidden when the flag is True.
+PROFILE_FIELD_FLAGS: Dict[str, str] = {
+    'bio': 'bio_friends_only',
+    'pronouns': 'pronouns_friends_only',
+}
+
+
+def apply_profile_view_as(data: dict, owner, tier: Optional[str]) -> dict:
+    """Mutate `data` in place to mask owner profile fields per the chosen tier.
+
+    Called only when `tier` is set and the requester is the owner. For the
+    binary `_friends_only` flags, masking applies only to the 'public' tier;
+    'friends' and 'close_friends' see the same fields a real friend sees.
+    """
+    if tier != 'public':
+        return data
+    for field, flag in PROFILE_FIELD_FLAGS.items():
+        if getattr(owner, flag, False) and field in data:
+            data[field] = None
+    return data

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -50,7 +50,7 @@ from account.serializers import (CurrentUserSerializer, CurrentUserSignupSeriali
                                  UserMinimalSerializer, \
                                  UserInterestUpdateSerializer, UserPersonaUpdateSerializer, \
                                  InterestSerializer, PersonaSerializer, viewer_sees_check_in_component)
-from account.view_as import apply_profile_view_as, parse_view_as, resolve_shadow_viewer
+from account.view_as import apply_profile_view_as, parse_view_as, resolve_public_proxy_viewer, resolve_shadow_viewer
 from adoorback.utils.content_types import get_generic_relation_type, get_friend_request_type
 from adoorback.utils.exceptions import ExistingUsername, LongUsername, InvalidUsername, ExistingEmail, InvalidEmail, \
     NoUsername, WrongPassword, ExistingUsername, InvalidInviterEmail
@@ -660,12 +660,20 @@ class UserProfile(generics.RetrieveAPIView):
         view_as = parse_view_as(request)  # raises 400 if invalid
         instance = self.get_object()
         shadow_viewer = resolve_shadow_viewer(request, instance)
+        # When the owner previews as 'public' (no specific friend chosen),
+        # use the configured non-friend proxy user as the shadow viewer so
+        # friendship-derived fields render as a real non-friend would see them.
+        if shadow_viewer is None and view_as == 'public' and request.user == instance:
+            shadow_viewer = resolve_public_proxy_viewer(instance)
         serializer = self.get_serializer(
             instance,
             context={**self.get_serializer_context(), 'view_as': view_as, 'shadow_viewer': shadow_viewer},
         )
         data = dict(serializer.data)
-        if view_as is not None and instance == request.user:
+        # Tier-mode field masking applies only when no shadow viewer was resolved.
+        # If a shadow_viewer is in play (real friend OR proxy), the serializer's
+        # _get_viewer-based masking already handled bio/pronouns/etc. correctly.
+        if view_as is not None and instance == request.user and shadow_viewer is None:
             apply_profile_view_as(data, instance, view_as)
         return Response(data)
 
@@ -1256,12 +1264,20 @@ class CurrentUserProfile(generics.RetrieveAPIView):
         view_as = parse_view_as(request)  # raises 400 if invalid
         instance = self.get_object()
         shadow_viewer = resolve_shadow_viewer(request, instance)
+        # When the owner previews as 'public' (no specific friend chosen),
+        # use the configured non-friend proxy user as the shadow viewer so
+        # friendship-derived fields render as a real non-friend would see them.
+        if shadow_viewer is None and view_as == 'public' and request.user == instance:
+            shadow_viewer = resolve_public_proxy_viewer(instance)
         serializer = self.get_serializer(
             instance,
             context={**self.get_serializer_context(), 'view_as': view_as, 'shadow_viewer': shadow_viewer},
         )
         data = dict(serializer.data)
-        if view_as is not None and instance == request.user:
+        # Tier-mode field masking applies only when no shadow viewer was resolved.
+        # If a shadow_viewer is in play (real friend OR proxy), the serializer's
+        # _get_viewer-based masking already handled bio/pronouns/etc. correctly.
+        if view_as is not None and instance == request.user and shadow_viewer is None:
             apply_profile_view_as(data, instance, view_as)
         return Response(data)
 

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -659,7 +659,7 @@ class UserProfile(generics.RetrieveAPIView):
     def retrieve(self, request, *args, **kwargs):
         view_as = parse_view_as(request)  # raises 400 if invalid
         instance = self.get_object()
-        serializer = self.get_serializer(instance)
+        serializer = self.get_serializer(instance, context={**self.get_serializer_context(), 'view_as': view_as})
         data = dict(serializer.data)
         if view_as is not None and instance == request.user:
             apply_profile_view_as(data, instance, view_as)
@@ -1251,7 +1251,7 @@ class CurrentUserProfile(generics.RetrieveAPIView):
     def retrieve(self, request, *args, **kwargs):
         view_as = parse_view_as(request)  # raises 400 if invalid
         instance = self.get_object()
-        serializer = self.get_serializer(instance)
+        serializer = self.get_serializer(instance, context={**self.get_serializer_context(), 'view_as': view_as})
         data = dict(serializer.data)
         if view_as is not None and instance == request.user:
             apply_profile_view_as(data, instance, view_as)

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -50,7 +50,7 @@ from account.serializers import (CurrentUserSerializer, CurrentUserSignupSeriali
                                  UserMinimalSerializer, \
                                  UserInterestUpdateSerializer, UserPersonaUpdateSerializer, \
                                  InterestSerializer, PersonaSerializer, viewer_sees_check_in_component)
-from account.view_as import apply_profile_view_as, parse_view_as
+from account.view_as import apply_profile_view_as, parse_view_as, resolve_shadow_viewer
 from adoorback.utils.content_types import get_generic_relation_type, get_friend_request_type
 from adoorback.utils.exceptions import ExistingUsername, LongUsername, InvalidUsername, ExistingEmail, InvalidEmail, \
     NoUsername, WrongPassword, ExistingUsername, InvalidInviterEmail
@@ -659,7 +659,11 @@ class UserProfile(generics.RetrieveAPIView):
     def retrieve(self, request, *args, **kwargs):
         view_as = parse_view_as(request)  # raises 400 if invalid
         instance = self.get_object()
-        serializer = self.get_serializer(instance, context={**self.get_serializer_context(), 'view_as': view_as})
+        shadow_viewer = resolve_shadow_viewer(request, instance)
+        serializer = self.get_serializer(
+            instance,
+            context={**self.get_serializer_context(), 'view_as': view_as, 'shadow_viewer': shadow_viewer},
+        )
         data = dict(serializer.data)
         if view_as is not None and instance == request.user:
             apply_profile_view_as(data, instance, view_as)
@@ -1251,7 +1255,11 @@ class CurrentUserProfile(generics.RetrieveAPIView):
     def retrieve(self, request, *args, **kwargs):
         view_as = parse_view_as(request)  # raises 400 if invalid
         instance = self.get_object()
-        serializer = self.get_serializer(instance, context={**self.get_serializer_context(), 'view_as': view_as})
+        shadow_viewer = resolve_shadow_viewer(request, instance)
+        serializer = self.get_serializer(
+            instance,
+            context={**self.get_serializer_context(), 'view_as': view_as, 'shadow_viewer': shadow_viewer},
+        )
         data = dict(serializer.data)
         if view_as is not None and instance == request.user:
             apply_profile_view_as(data, instance, view_as)

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -50,6 +50,7 @@ from account.serializers import (CurrentUserSerializer, CurrentUserSignupSeriali
                                  UserMinimalSerializer, \
                                  UserInterestUpdateSerializer, UserPersonaUpdateSerializer, \
                                  InterestSerializer, PersonaSerializer, viewer_sees_check_in_component)
+from account.view_as import apply_profile_view_as, parse_view_as
 from adoorback.utils.content_types import get_generic_relation_type, get_friend_request_type
 from adoorback.utils.exceptions import ExistingUsername, LongUsername, InvalidUsername, ExistingEmail, InvalidEmail, \
     NoUsername, WrongPassword, ExistingUsername, InvalidInviterEmail
@@ -655,6 +656,15 @@ class UserProfile(generics.RetrieveAPIView):
     def get_exception_handler(self):
         return adoor_exception_handler
 
+    def retrieve(self, request, *args, **kwargs):
+        view_as = parse_view_as(request)  # raises 400 if invalid
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        data = dict(serializer.data)
+        if view_as is not None and instance == request.user:
+            apply_profile_view_as(data, instance, view_as)
+        return Response(data)
+
 
 class UserNoteList(generics.ListAPIView):
     serializer_class = NoteSerializer
@@ -1237,6 +1247,15 @@ class CurrentUserProfile(generics.RetrieveAPIView):
             return user
         else:
             raise PermissionDenied("User is not authenticated")
+
+    def retrieve(self, request, *args, **kwargs):
+        view_as = parse_view_as(request)  # raises 400 if invalid
+        instance = self.get_object()
+        serializer = self.get_serializer(instance)
+        data = dict(serializer.data)
+        if view_as is not None and instance == request.user:
+            apply_profile_view_as(data, instance, view_as)
+        return Response(data)
 
 
 class CurrentUserNoteList(generics.ListAPIView):


### PR DESCRIPTION
## Summary

Backend support for the View As profile preview feature.

- New `?view_as=public|friends|close_friends` query param: tier-mode masking on `/api/user/me/profile/` and `/api/user/<username>/profile/`. Honored only when the requester is the profile owner; ignored otherwise (silently, no abuse vector).
- New `?view_as_user=<username>` query param: **shadow-viewer mode**. The chosen user becomes the effective viewer for serialization — all friendship-derived fields (`mutuals`, `connection_status`, `are_friends`, `friendship_level`, etc.) compute from that user's relationship to the owner. The existing `_passes_close_friends` upgrade-time cutoff fires correctly with the shadow viewer's real `Connection.upgrade_time` and `update_past_posts` flag, so the preview reflects the actual close-friends visibility window.
- `?view_as=public` automatically resolves to a configured non-friend proxy user (default `wit_bot`, override via `settings.VIEW_AS_PUBLIC_PROXY_USERNAME`). When the proxy doesn't exist or has somehow become a friend of the owner, falls back to the existing tier-mode field masking.
- `UserProfileSerializer.to_representation` and 14 `get_*` methods consult a shared `_get_viewer()` helper that returns shadow_viewer if set, else `request.user`. No mocking; existing masking logic battle-tested by production friend views runs unchanged.

Tests: 32 view_as-specific tests covering parser, resolver, owner-only gating, public-proxy fallback, friend / close-friend / non-friend perspective rendering. Full account suite: 60 tests, no regressions.

## Test plan

- [ ] `python manage.py check` clean
- [ ] `python manage.py makemigrations --check` clean (no model changes)
- [ ] `python manage.py test account` — 60 tests pass
- [ ] Manual: hit `/api/user/me/profile/?view_as_user=<a friend's username>` as the owner; response's `mutuals`, `connection_status`, `are_friends` reflect that friend's actual relationship to the owner
- [ ] Manual: hit `/api/user/me/profile/?view_as=public`; response is rendered from `wit_bot`'s perspective
- [ ] Manual: as a non-owner, hit `/api/user/<other>/profile/?view_as=close_friends`; param is ignored (response based on actual relationship)