### PR TITLE
feat: #935 version isolation between users

### DIFF
--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -597,13 +597,13 @@ class UserSearch(generics.ListAPIView):
         qs = User.objects.none()
         if query:
             # username starts with query
-            start_users = User.objects.filter(username__startswith=query, is_superuser=False) \
+            start_users = User.objects.filter(username__startswith=query, is_superuser=False, current_ver=user.current_ver) \
                 .order_by('username').exclude(id=user_id).exclude(id__in=user_block_rec_ids)
             friend_start_ids = list(start_users.filter(id__in=friend_ids).values_list('id', flat=True))
             nonfriend_start_ids = list(start_users.exclude(id__in=friend_ids).values_list('id', flat=True))
 
             # username contains query
-            contain_users = User.objects.filter(username__icontains=query, is_superuser=False) \
+            contain_users = User.objects.filter(username__icontains=query, is_superuser=False, current_ver=user.current_ver) \
                 .order_by('username').exclude(id=user_id).exclude(id__in=user_block_rec_ids)
             friend_contain_ids = list(contain_users.filter(id__in=friend_ids).values_list('id', flat=True))
             nonfriend_contain_ids = list(contain_users.exclude(id__in=friend_ids).values_list('id', flat=True))
@@ -1421,7 +1421,7 @@ class FriendList(generics.ListAPIView):
             return self._qs
 
         user = self.request.user
-        friends = user.connected_users
+        friends = user.connected_users.filter(current_ver=user.current_ver)
 
         query_type = self.request.query_params.get('type')
 
@@ -2551,7 +2551,10 @@ class FriendFeed(generics.ListAPIView):
     def get_queryset(self):
         user = self.request.user
 
-        connected_user_ids = user.connected_user_ids
+        # Filter connected users to same version
+        connected_user_ids = list(User.objects.filter(
+            id__in=user.connected_user_ids, current_ver=user.current_ver
+        ).values_list('id', flat=True))
         blocked_user_ids = user.user_report_blocked_ids
 
         notes = Note.objects.filter(
@@ -2608,7 +2611,10 @@ class FullFriendFeed(generics.ListAPIView):
 
     def get_combined_feed_items(self):
         user = self.request.user
-        connected_user_ids = user.connected_user_ids
+        # Filter connected users to same version
+        connected_user_ids = list(User.objects.filter(
+            id__in=user.connected_user_ids, current_ver=user.current_ver
+        ).values_list('id', flat=True))
         blocked_user_ids = user.user_report_blocked_ids
 
         # 1. Notes
@@ -2771,8 +2777,8 @@ class DiscoverFeedView(generics.ListAPIView):
 
         # 1, 2, 3. Collect candidates for Mutual Friends, Mutual Traits, and Strangers
 
-        # Mutual Friends Candidates
-        user_friends = user.connected_users
+        # Mutual Friends Candidates (same version only)
+        user_friends = user.connected_users.filter(current_ver=user.current_ver)
         user_friend_ids = set(user_friends.values_list('id', flat=True))
         mutual_friend_potential_ids = set()
         for friend in user_friends:
@@ -2786,13 +2792,16 @@ class DiscoverFeedView(generics.ListAPIView):
         user_interests = set(user.user_interests.values_list('id', flat=True))
         user_personas = set(user.user_personas.values_list('id', flat=True))
         trait_ids = set(User.objects.filter(
-            Q(user_interests__id__in=user_interests) | Q(user_personas__id__in=user_personas)
+            Q(user_interests__id__in=user_interests) | Q(user_personas__id__in=user_personas),
+            current_ver=user.current_ver
         ).exclude(id__in=exclude_ids).values_list('id', flat=True))
 
         trait_candidates = get_candidates(trait_ids, limit=20)
 
         # Strangers (No Mutual) Candidates
-        stranger_ids = set(User.objects.exclude(
+        stranger_ids = set(User.objects.filter(
+            current_ver=user.current_ver
+        ).exclude(
             id__in=exclude_ids | mutual_friend_potential_ids | trait_ids
         ).exclude(is_superuser=True).values_list('id', flat=True))
         
@@ -2837,14 +2846,16 @@ class DiscoverFeedView(generics.ListAPIView):
         if len(feed_items) < 10:
             # Random Response — only public
             random_responses = list(_Response.objects.filter(
-                visibility__contains=['public']
+                visibility__contains=['public'],
+                author__current_ver=user.current_ver
             ).exclude(
                 author_id__in=exclude_ids
             ).exclude(readers=user).order_by('-created_at')[:50])
 
             # Random Note — only public
             random_notes = list(Note.objects.filter(
-                visibility__contains=['public']
+                visibility__contains=['public'],
+                author__current_ver=user.current_ver
             ).exclude(
                 author_id__in=exclude_ids
             ).exclude(readers=user).order_by('-created_at')[:50])
@@ -2880,6 +2891,7 @@ class DiscoverFeedView(generics.ListAPIView):
         from check_in.models import Song, CheckIn as CheckInModel
         music_candidates = Song.objects.filter(
             is_active=True,
+            user__current_ver=user.current_ver,
         ).exclude(
             user_id__in=exclude_ids
         ).select_related('user').order_by('-created_at')[:40]

--- a/adoorback/chat/views.py
+++ b/adoorback/chat/views.py
@@ -215,6 +215,17 @@ class ChatRoomList(generics.ListAPIView):
         if user.email not in ALL_OPERATOR_EMAILS:
             qs = qs.exclude(is_wit_admin_proxy=True)
 
+        # Version isolation: hide 1-on-1 rooms where the other user is on a different version
+        # (exclude WIT Admin rooms which are pinned and version-agnostic)
+        qs = qs.exclude(
+            Q(is_group=False) & ~Q(
+                Q(user1__username=WIT_ADMIN_USERNAME) | Q(user2__username=WIT_ADMIN_USERNAME)
+            ) & (
+                (Q(user1=user) & ~Q(user2__current_ver=user.current_ver)) |
+                (Q(user2=user) & ~Q(user1__current_ver=user.current_ver))
+            )
+        )
+
         annotated = qs.annotate(
             last_message_time=Subquery(latest_msg.values('created_at')[:1]),
             last_message_content=Subquery(latest_msg.values('content')[:1]),
@@ -353,6 +364,10 @@ class MessageList(generics.ListCreateAPIView):
                 Q(is_wit_admin_proxy=True) | Q(is_wit_admin_blast_room=True)
             ).exists()
         )
+
+        # Version isolation: block messaging across different versions
+        if not is_wit_admin_surface and user.current_ver != connected_user.current_ver:
+            raise exceptions.PermissionDenied("Cannot message users on a different version.")
 
         if not is_wit_admin_surface and not user.is_connected(connected_user):
             req = ChatRequest.objects.filter(
@@ -633,6 +648,10 @@ class ChatRequestCreate(generics.ListCreateAPIView):
         requestee_id = serializer.validated_data['requestee_id']
         requestee = User.objects.get(id=requestee_id)
 
+        # Version isolation
+        if user.current_ver != requestee.current_ver:
+            raise exceptions.PermissionDenied("Cannot send chat request to a user on a different version.")
+
         if user.is_connected(requestee):
             raise exceptions.ValidationError("You are already friends. No request needed.")
 
@@ -786,6 +805,10 @@ class GroupChatCreate(generics.CreateAPIView):
         if members.count() != len(all_member_ids):
             raise exceptions.NotFound("One or more users not found.")
 
+        # Version isolation: all members must be on the same version
+        if members.exclude(current_ver=user.current_ver).exists():
+            raise exceptions.ValidationError("Cannot create a group with members on a different version.")
+
         room = ChatRoom.objects.create(is_group=True, name=name)
         room.members.set(members)
 
@@ -836,6 +859,10 @@ class GroupChatUpdate(generics.GenericAPIView):
             if current_count + len(add_ids) > MAX_GROUP_MEMBERS:
                 raise exceptions.ValidationError(f"Group cannot exceed {MAX_GROUP_MEMBERS} members.")
             new_members = list(User.objects.filter(id__in=add_ids))
+            # Version isolation: new members must be on the same version
+            diff_ver = [m for m in new_members if m.current_ver != user.current_ver]
+            if diff_ver:
+                raise exceptions.ValidationError("Cannot add members on a different version.")
             room.members.add(*new_members)
             if new_members:
                 added_msg = Message.objects.create(
@@ -929,6 +956,10 @@ class GroupMessageList(generics.ListCreateAPIView):
 
         if not room.members.filter(id=user.id).exists():
             raise exceptions.PermissionDenied("You are not a member of this group.")
+
+        # Version isolation: block if group has members on different versions
+        if room.members.exclude(current_ver=user.current_ver).exists():
+            raise exceptions.PermissionDenied("Cannot send messages in a group with members on different versions.")
 
         parent_id = self.request.data.get('parent')
         parent = None

--- a/adoorback/check_in/views.py
+++ b/adoorback/check_in/views.py
@@ -607,6 +607,10 @@ class PokeCreate(generics.CreateAPIView):
         if sender == receiver:
             raise exceptions.ValidationError("You cannot poke yourself.")
 
+        # Version isolation
+        if sender.current_ver != receiver.current_ver:
+            raise exceptions.PermissionDenied("Cannot poke a user on a different version.")
+
         # Check daily poke limit
         today_start = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
         sent_today = Poke.objects.filter(sender=sender, created_at__gte=today_start).count()
@@ -697,6 +701,10 @@ class CheckInReact(APIView):
             check_in = CheckIn.objects.get(id=pk)
         except CheckIn.DoesNotExist:
             raise exceptions.NotFound("Check-in not found.")
+
+        # Version isolation
+        if check_in.user.current_ver != request.user.current_ver:
+            raise exceptions.PermissionDenied("Cannot interact with a check-in from a user on a different version.")
 
         if not check_in.is_active:
             raise exceptions.PermissionDenied("This check-in is no longer active.")
@@ -847,7 +855,10 @@ class CheckInPostFeed(generics.ListCreateAPIView):
 
     def get_queryset(self):
         user = self.request.user
-        connected_ids = list(user.connected_user_ids)
+        # Filter connected users to same version
+        connected_ids = list(User.objects.filter(
+            id__in=user.connected_user_ids, current_ver=user.current_ver
+        ).values_list('id', flat=True))
         blocked_ids = user.user_report_blocked_ids
 
         qs = CheckInPost.objects.filter(
@@ -919,7 +930,10 @@ class CheckInPostStories(generics.ListAPIView):
         # so excluding the viewer here keeps the feed strip purely about
         # friends without breaking the author's own archive UX.
         user = self.request.user
-        connected_ids = list(user.connected_user_ids)
+        # Filter connected users to same version
+        connected_ids = list(User.objects.filter(
+            id__in=user.connected_user_ids, current_ver=user.current_ver
+        ).values_list('id', flat=True))
         blocked_ids = user.user_report_blocked_ids
 
         author_ids = [uid for uid in connected_ids if uid not in blocked_ids]

--- a/adoorback/comment/views.py
+++ b/adoorback/comment/views.py
@@ -24,7 +24,18 @@ class CommentCreate(generics.CreateAPIView):
 
     @transaction.atomic
     def perform_create(self, serializer):
-        content_type_id = get_generic_relation_type(self.request.data['target_type']).id
+        content_type = get_generic_relation_type(self.request.data['target_type'])
+        content_type_id = content_type.id
+
+        # Version isolation: block commenting on content from users on a different version
+        target_model = content_type.model_class()
+        try:
+            target_obj = target_model.objects.get(id=self.request.data['target_id'])
+            target_author = getattr(target_obj, 'author', None) or getattr(target_obj, 'user', None)
+            if target_author and target_author.current_ver != self.request.user.current_ver:
+                raise PermissionDenied("Cannot interact with content from a user on a different version.")
+        except target_model.DoesNotExist:
+            pass
 
         # check if blocked/blocking user is tagged
         tagged_users, _ = parse_user_tag_from_content(self.request.data['content'])

--- a/adoorback/like/views.py
+++ b/adoorback/like/views.py
@@ -22,7 +22,19 @@ class LikeCreate(generics.CreateAPIView):
 
     @transaction.atomic
     def perform_create(self, serializer):
-        content_type_id = get_generic_relation_type(self.request.data['target_type']).id
+        content_type = get_generic_relation_type(self.request.data['target_type'])
+        content_type_id = content_type.id
+
+        # Version isolation: block liking content from users on a different version
+        target_model = content_type.model_class()
+        try:
+            target_obj = target_model.objects.get(id=self.request.data['target_id'])
+            target_author = getattr(target_obj, 'author', None) or getattr(target_obj, 'user', None)
+            if target_author and target_author.current_ver != self.request.user.current_ver:
+                raise ValidationError("Cannot interact with content from a user on a different version.")
+        except target_model.DoesNotExist:
+            pass
+
         try:
             instance = serializer.save(
                 user=self.request.user,

--- a/adoorback/qna/views.py
+++ b/adoorback/qna/views.py
@@ -285,6 +285,9 @@ class ResponseRequestCreate(generics.CreateAPIView):
             raise PermissionDenied("requester가 본인이 아닙니다.")
         if not requestee.is_connected(current_user):
             raise PermissionDenied("친구에게만 response request를 보낼 수 있습니다.")
+        # Version isolation
+        if requester.current_ver != requestee.current_ver:
+            raise PermissionDenied("Cannot send response requests to users on a different version.")
         
         # Do nothing if request already exists
         exists = ResponseRequest.objects.filter(

--- a/adoorback/reaction/views.py
+++ b/adoorback/reaction/views.py
@@ -1,5 +1,6 @@
 from django.db import transaction, IntegrityError
 from rest_framework import generics
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 
 from reaction.models import Reaction
@@ -45,6 +46,11 @@ class ReactionList(generics.ListCreateAPIView):
     @transaction.atomic
     def perform_create(self, serializer):
         target, content_type_id, object_id = self.validate_target()
+
+        # Version isolation: block reacting to content from users on a different version
+        target_author = getattr(target, 'author', None) or getattr(target, 'user', None)
+        if target_author and target_author.current_ver != self.request.user.current_ver:
+            raise PermissionDenied("Cannot interact with content from a user on a different version.")
 
         try:
             serializer.save(user=self.request.user,


### PR DESCRIPTION
# Version Isolation Between Users

Users are assigned a `current_ver` (`version_w` or `version_q`) that determines which app version they use. Every 2 weeks, all users swap versions simultaneously. Users on different `current_ver` values must not discover, see, or interact with each other.

## What Was Already in Place

- **Friend recommendations** filtered by `current_ver`
- **Friend request creation/acceptance** blocked across versions

## What Was Added

### Discovery & Feeds

| Area | File | Change |
|------|------|--------|
| User search | `account/views.py` | Search results filtered to same `current_ver` |
| Discover feed | `account/views.py` | All candidate pools (mutual friends, traits, strangers, random posts, music) filtered by version |
| Friend feed | `account/views.py` | `FriendFeed` and `FullFriendFeed` scoped to same-version friends |
| Friend list | `account/views.py` | Only same-version friends shown |
| Check-in post feed | `check_in/views.py` | Feed and stories strip scoped to same-version friends |

### Chat & Messaging

| Area | File | Change |
|------|------|--------|
| 1:1 DM | `chat/views.py` | Blocked when recipient is on a different version (WIT Admin exempt) |
| Chat request | `chat/views.py` | Blocked across versions |
| Group chat create | `chat/views.py` | All members must share the same version |
| Group member add | `chat/views.py` | New members must match the group's version |
| Group message send | `chat/views.py` | Blocked if any member is on a different version (handles post-swap state) |
| Chat room list | `chat/views.py` | Cross-version 1:1 rooms hidden (WIT Admin rooms exempt) |

### Content Interactions

| Area | File | Change |
|------|------|--------|
| Comments | `comment/views.py` | Cannot comment on content authored by a cross-version user |
| Likes | `like/views.py` | Cannot like content authored by a cross-version user |
| Reactions | `reaction/views.py` | Cannot react to content authored by a cross-version user |
| Check-in reactions | `check_in/views.py` | Cannot react to a cross-version user's check-in |
| Pokes | `check_in/views.py` | Cannot poke a cross-version user |
| QnA response requests | `qna/views.py` | Cannot request a response from a cross-version user |

## WIT Admin Exception

All chat-related version checks skip WIT Admin surfaces (`is_wit_admin_surface`). Operator and support chats are version-agnostic by design.

## Edge Cases

- **Existing friends across groups**: After a swap, friends from different `user_group` values end up on opposite versions. They are filtered out of feeds and friend lists until the next swap realigns them.
- **Existing group chats**: If a swap leaves members on different versions, message sending is blocked until versions realign.
- **Existing 1:1 chat rooms**: Hidden from the chat room list while versions differ.
