### PR TITLE
feat: #945 Q discover API

### DIFF
--- a/adoorback/account/tests_q.py
+++ b/adoorback/account/tests_q.py
@@ -207,6 +207,182 @@ class CrossVersionFriendRequestTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
 
+class QDiscoverFeedTests(APITestCase):
+    """Test Version Q /api/q/user/discover/ endpoint."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='testuser', email='test@test.com', password='password',
+            current_ver='version_q', user_group='group_q_first'
+        )
+        self.friend = User.objects.create_user(
+            username='friend', email='friend@test.com', password='password',
+            current_ver='version_q'
+        )
+        self.stranger = User.objects.create_user(
+            username='stranger', email='stranger@test.com', password='password',
+            current_ver='version_q'
+        )
+        self.stranger2 = User.objects.create_user(
+            username='stranger2', email='stranger2@test.com', password='password',
+            current_ver='version_q'
+        )
+        self.user_w = User.objects.create_user(
+            username='user_w', email='w@test.com', password='password',
+            current_ver='version_w'
+        )
+        self.blocked_user = User.objects.create_user(
+            username='blocked', email='blocked@test.com', password='password',
+            current_ver='version_q'
+        )
+        self.admin = User.objects.create_superuser(
+            username='admin', email='admin@test.com', password='password'
+        )
+
+        # Create friendship
+        Connection.objects.create(
+            user1=self.user, user2=self.friend,
+            user1_choice='friend', user2_choice='friend'
+        )
+
+        # Create block
+        from user_report.models import UserReport
+        UserReport.objects.create(user=self.user, reported_user=self.blocked_user)
+
+        # Create a question for responses
+        self.question = Question.objects.create(
+            author=self.admin, content='Test question?'
+        )
+
+        # Public posts from stranger (should appear)
+        self.stranger_note = Note.objects.create(
+            author=self.stranger, content='Stranger public note',
+            visibility=['public']
+        )
+        self.stranger_response = Response.objects.create(
+            author=self.stranger, question=self.question,
+            content='Stranger public response', visibility=['public']
+        )
+
+        # Public post from friend (should NOT appear)
+        Note.objects.create(
+            author=self.friend, content='Friend public note',
+            visibility=['public']
+        )
+
+        # Non-public post from stranger (should NOT appear)
+        Note.objects.create(
+            author=self.stranger, content='Stranger private note',
+            visibility=['friends']
+        )
+
+        # Public post from blocked user (should NOT appear)
+        Note.objects.create(
+            author=self.blocked_user, content='Blocked user note',
+            visibility=['public']
+        )
+
+        # Public post from ver.w user (should NOT appear)
+        Note.objects.create(
+            author=self.user_w, content='Other version note',
+            visibility=['public']
+        )
+
+        # Public post from superuser (should NOT appear)
+        Note.objects.create(
+            author=self.admin, content='Admin note',
+            visibility=['public']
+        )
+
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse('q-discover-feed')
+
+    def test_returns_public_posts_from_non_friends(self):
+        """Discover should return public posts from non-friends only."""
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.data.get('results', response.data)
+        authors = [item['body']['author_detail']['username'] for item in results]
+        self.assertIn('stranger', authors)
+        self.assertNotIn('friend', authors)
+
+    def test_excludes_blocked_users(self):
+        """Discover should exclude posts from blocked users."""
+        response = self.client.get(self.url)
+        results = response.data.get('results', response.data)
+        authors = [item['body']['author_detail']['username'] for item in results]
+        self.assertNotIn('blocked', authors)
+
+    def test_excludes_other_version(self):
+        """Discover should exclude posts from users on different version."""
+        response = self.client.get(self.url)
+        results = response.data.get('results', response.data)
+        authors = [item['body']['author_detail']['username'] for item in results]
+        self.assertNotIn('user_w', authors)
+
+    def test_excludes_superusers(self):
+        """Discover should exclude posts from superusers."""
+        response = self.client.get(self.url)
+        results = response.data.get('results', response.data)
+        authors = [item['body']['author_detail']['username'] for item in results]
+        self.assertNotIn('admin', authors)
+
+    def test_excludes_non_public_posts(self):
+        """Discover should only return posts with public visibility."""
+        response = self.client.get(self.url)
+        results = response.data.get('results', response.data)
+        contents = [item['body']['content'] for item in results]
+        self.assertNotIn('Stranger private note', contents)
+
+    def test_returns_both_notes_and_responses(self):
+        """Discover should return both Note and Response types."""
+        response = self.client.get(self.url)
+        results = response.data.get('results', response.data)
+        types = [item['type'] for item in results]
+        self.assertIn('Note', types)
+        self.assertIn('Response', types)
+
+    def test_wrapper_format(self):
+        """Each item should have type and body keys."""
+        response = self.client.get(self.url)
+        results = response.data.get('results', response.data)
+        for item in results:
+            self.assertIn('type', item)
+            self.assertIn('body', item)
+            self.assertIn(item['type'], ['Note', 'Response'])
+
+    def test_reverse_chronological_order(self):
+        """Posts should be ordered newest first."""
+        # Create a newer post from stranger2
+        Note.objects.create(
+            author=self.stranger2, content='Newer note',
+            visibility=['public']
+        )
+        response = self.client.get(self.url)
+        results = response.data.get('results', response.data)
+        timestamps = [item['body']['created_at'] for item in results]
+        self.assertEqual(timestamps, sorted(timestamps, reverse=True))
+
+    def test_marks_as_read(self):
+        """Fetching discover should mark posts as read."""
+        self.assertFalse(self.user.read_notes.filter(id=self.stranger_note.id).exists())
+        self.assertFalse(self.user.read_responses.filter(id=self.stranger_response.id).exists())
+
+        self.client.get(self.url)
+
+        self.assertTrue(self.user.read_notes.filter(id=self.stranger_note.id).exists())
+        self.assertTrue(self.user.read_responses.filter(id=self.stranger_response.id).exists())
+
+    def test_uses_q_serializers(self):
+        """Discover should use Q serializers (no share_type, no reactions)."""
+        response = self.client.get(self.url)
+        results = response.data.get('results', response.data)
+        for item in results:
+            self.assertNotIn('share_type', item['body'])
+            self.assertNotIn('current_user_reaction_id_list', item['body'])
+            self.assertIn('like_count', item['body'])
+
+
 class RemovedDefaultEndpointTests(APITestCase):
     """Test that old /default/ endpoints are gone."""
 

--- a/adoorback/account/urls_q.py
+++ b/adoorback/account/urls_q.py
@@ -14,4 +14,7 @@ urlpatterns = [
 
     # Feed (Q: notes only with Q serializer)
     path('feed/', views_q.QFriendFeed.as_view(), name='q-friend-feed'),
+
+    # Discover (Q: public posts from non-friends, reverse chronological)
+    path('discover/', views_q.QDiscoverFeed.as_view(), name='q-discover-feed'),
 ]

--- a/adoorback/account/views_q.py
+++ b/adoorback/account/views_q.py
@@ -1,5 +1,9 @@
 from itertools import chain
+from operator import attrgetter
 
+from django.contrib.contenttypes.models import ContentType
+from rest_framework import generics
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response as DRFResponse
 
 from account.serializers_q import QCurrentUserSerializer, QUserProfileSerializer
@@ -7,6 +11,7 @@ from account.views import (
     CurrentUserDetail, UserProfile, CurrentUserNoteList, UserNoteList,
     CurrentUserAllPostList, UserAllPostList, FriendFeed,
 )
+from adoorback.utils.validators import adoor_exception_handler
 from note.models import Note
 from note.serializers_q import QNoteSerializer
 from qna.models import Response as _Response
@@ -103,3 +108,80 @@ class QUserAllPostList(UserAllPostList):
             obj.readers.add(user)
 
         return self.get_paginated_response(serialized_data) if page is not None else DRFResponse(serialized_data)
+
+
+class QDiscoverFeed(generics.ListAPIView):
+    """Discover feed for Version Q: public posts from non-friends, reverse chronological."""
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def get_combined_feed_items(self):
+        user = self.request.user
+
+        exclude_ids = set(user.connected_user_ids + user.user_report_blocked_ids + [user.id])
+
+        # Exclude content-reported posts at queryset level
+        from content_report.models import ContentReport
+        note_ct = ContentType.objects.get_for_model(Note)
+        response_ct = ContentType.objects.get_for_model(_Response)
+        reported_note_ids = set(ContentReport.objects.filter(
+            user=user, content_type=note_ct
+        ).values_list('object_id', flat=True))
+        reported_response_ids = set(ContentReport.objects.filter(
+            user=user, content_type=response_ct
+        ).values_list('object_id', flat=True))
+
+        notes = list(Note.objects.filter(
+            visibility__contains=['public'],
+            author__current_ver=user.current_ver,
+        ).exclude(
+            author_id__in=exclude_ids,
+        ).exclude(
+            author__is_superuser=True,
+        ).exclude(
+            id__in=reported_note_ids,
+        ).select_related('author').order_by('-created_at'))
+
+        responses = list(_Response.objects.filter(
+            visibility__contains=['public'],
+            author__current_ver=user.current_ver,
+        ).exclude(
+            author_id__in=exclude_ids,
+        ).exclude(
+            author__is_superuser=True,
+        ).exclude(
+            id__in=reported_response_ids,
+        ).select_related('author', 'question').order_by('-created_at'))
+
+        combined = sorted(chain(notes, responses), key=attrgetter('created_at'), reverse=True)
+        return notes, responses, combined
+
+    def list(self, request, *args, **kwargs):
+        user = request.user
+        notes, responses, combined = self.get_combined_feed_items()
+
+        page = self.paginate_queryset(combined)
+        objects_to_serialize = page if page is not None else combined
+
+        serialized_data = []
+        for obj in objects_to_serialize:
+            if isinstance(obj, Note):
+                body = QNoteSerializer(obj, context=self.get_serializer_context()).data
+                serialized_data.append({'type': 'Note', 'body': body})
+            elif isinstance(obj, _Response):
+                body = QResponseSerializer(obj, context=self.get_serializer_context()).data
+                serialized_data.append({'type': 'Response', 'body': body})
+
+        # Mark as read
+        note_ids_to_read = [obj.id for obj in objects_to_serialize if isinstance(obj, Note)]
+        response_ids_to_read = [obj.id for obj in objects_to_serialize if isinstance(obj, _Response)]
+        if note_ids_to_read:
+            user.read_notes.add(*note_ids_to_read)
+        if response_ids_to_read:
+            user.read_responses.add(*response_ids_to_read)
+
+        if page is not None:
+            return self.get_paginated_response(serialized_data)
+        return DRFResponse(serialized_data)


### PR DESCRIPTION
# Ver.Q Discover Feed

## Endpoint

`GET /api/q/user/discover/`

Authenticated. Standard DRF pagination (`?page=N`).

## Behavior

A simple public feed for ver.q users — all public posts from non-friends, newest first.

### What it returns

- **Note** and **Response** objects with `visibility = ['public']`
- Ordered by `created_at` descending (newest first)
- No count limit per day — standard paginated list
- Posts are marked as read after fetching

### What it excludes

| Excluded | Reason |
|----------|--------|
| Friends / close friends | Discover is for non-connected users only |
| Self | User's own posts |
| Blocked users | Both directions (`UserReport`) |
| Content-reported posts | `ContentReport` by requesting user |
| Superusers | Admin accounts |
| Other-version users | Only shows posts from same `current_ver` |

### Response format

```json
{
  "count": 42,
  "next": "https://.../api/q/user/discover/?page=2",
  "previous": null,
  "results": [
    {
      "type": "Note",
      "body": { /* QNoteSerializer output */ }
    },
    {
      "type": "Response",
      "body": { /* QResponseSerializer output */ }
    }
  ]
}
```

Each item is wrapped in `{type, body}` matching the ver.w discover format. No `category` field (ver.w only).

## Comparison with Ver.W Discover

| | Ver.W | Ver.Q |
|---|---|---|
| Content types | Note + Response + Question + Interest + Music | Note + Response only |
| Source | 3 categories (mutual friends, traits, strangers) | All non-friends |
| Daily limit | 10 posts + 10 songs | No limit |
| Caching | `DiscoverFeed` model, regenerated daily | Real-time query |
| Injected cards | Question, Interest, Persona, Music | None |

## Files changed

### Backend

| File | Change |
|------|--------|
| `account/views_q.py` | Added `QDiscoverFeed` view class |
| `account/urls_q.py` | Added `discover/` URL pattern |
| `account/tests_q.py` | Added `QDiscoverFeedTests` (10 test cases) |

### Frontend

| File | Change |
|------|--------|
| `src/utils/apis/discover.ts` | Added `apiPrefix` param to `getDiscoverFeed()` |
| `src/routes/discover/Discover.tsx` | Version-aware SWR key (`/q/user/discover/`) and refresh |

No new models, migrations, or frontend components.
