### PR TITLE
feat: #947 public/private account setting for ver.Q

### DIFF
--- a/adoorback/account/migrations/0051_user_is_public.py
+++ b/adoorback/account/migrations/0051_user_is_public.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('account', '0050_backfill_subscription_type'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='is_public',
+            field=models.BooleanField(null=True, blank=True),
+        ),
+    ]

--- a/adoorback/account/migrations/0052_backfill_is_public.py
+++ b/adoorback/account/migrations/0052_backfill_is_public.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def backfill_is_public(apps, schema_editor):
+    User = apps.get_model('account', 'User')
+    User.objects.filter(is_public__isnull=True).update(is_public=True)
+
+
+def reverse_backfill(apps, schema_editor):
+    User = apps.get_model('account', 'User')
+    User.objects.update(is_public=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('account', '0051_user_is_public'),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_is_public, reverse_backfill),
+    ]

--- a/adoorback/account/migrations/0053_is_public_not_null.py
+++ b/adoorback/account/migrations/0053_is_public_not_null.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('account', '0052_backfill_is_public'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='user',
+            name='is_public',
+            field=models.BooleanField(default=True),
+        ),
+    ]

--- a/adoorback/account/models.py
+++ b/adoorback/account/models.py
@@ -278,6 +278,7 @@ class User(AbstractUser, AdoorTimestampedModel, SafeDeleteModel):
     invited_from = models.ForeignKey('self', null=True, blank=True, on_delete=models.SET_NULL, 
                                      related_name="invited_users")
     
+    is_public = models.BooleanField(default=True)
     has_changed_pw = models.BooleanField(default=False)
     username_history = ArrayField(
         base_field=models.CharField(max_length=50),

--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -205,7 +205,7 @@ class CurrentUserSerializer(CountryFieldMixin, serializers.HyperlinkedModelSeria
                   'signature', 'date_of_signature', 'unread_noti', 'unread_noti_cnt', 
                   'noti_time', 'noti_period_days',
                   'timezone', 'current_ver', 'user_group', 'user_type',
-                  'has_changed_pw', 'unread_message_cnt']
+                  'has_changed_pw', 'unread_message_cnt', 'is_public']
         extra_kwargs = {'password': {'write_only': True}}
 
 

--- a/adoorback/account/views_q.py
+++ b/adoorback/account/views_q.py
@@ -22,6 +22,22 @@ class QCurrentUserDetail(CurrentUserDetail):
     """Current user detail for Version Q (no chip categories/custom chips)."""
     serializer_class = QCurrentUserSerializer
 
+    def perform_update(self, serializer):
+        user = self.get_object()
+        was_public = user.is_public
+
+        super().perform_update(serializer)
+
+        user.refresh_from_db()
+        if was_public and not user.is_public:
+            # Public -> Private: convert all public posts to friends-only
+            Note.objects.filter(
+                author=user, visibility__contains=['public']
+            ).update(visibility=['friends'])
+            _Response.objects.filter(
+                author=user, visibility__contains=['public']
+            ).update(visibility=['friends'])
+
 
 class QUserProfile(UserProfile):
     """User profile for Version Q (no chip-related fields)."""


### PR DESCRIPTION
# Ver.Q Public/Private Account Setting

## Overview

Instagram-style account privacy toggle for ver.q users. Public accounts can create posts visible to everyone; private accounts are limited to friends/close friends.

## Account Setting

- Field: `User.is_public` (BooleanField, default `True`)
- Toggle: My Page button (replaces "View As" for ver.q)
- New accounts default to **public**

## Post Visibility by Account Type

| Account | Default visibility | Options |
|---------|-------------------|---------|
| Public | `public` | public, close friends |
| Private | `friends` | friends, close friends |

Applies to both Note and Response creation.

## Public-to-Private Conversion

When switching from public to private:
- All existing posts with `visibility=['public']` are bulk-converted to `['friends']`
- This is **irreversible** — switching back to public does not restore previous visibility
- User is warned via confirmation dialog before proceeding
- Conversion runs in the same DB transaction as the profile update

## Discover Feed Integration

`QDiscoverFeed` already filters by `visibility__contains=['public']`. No changes needed — when a user goes private, their posts automatically disappear from discover.

## API

`PATCH /api/q/user/me/` with `{ "is_public": false }` (or `true`)

The `is_public` field is included in `GET /api/q/user/me/` response.

## Files Changed

### Backend

| File | Change |
|------|--------|
| `account/models.py` | Added `is_public` field |
| `account/serializers.py` | Exposed `is_public` in `CurrentUserSerializer` |
| `account/views_q.py` | `QCurrentUserDetail.perform_update` — bulk converts posts on public-to-private switch |
| `account/migrations/0051-0053` | 3-step migration (nullable add, backfill, NOT NULL) |

### Frontend

| File | Change |
|------|--------|
| `models/api/user.ts` | Added `is_public` to `MyProfile` |
| `utils/apis/my.ts` | Added `is_public` to `editProfile` type |
| `components/profile/Profile.tsx` | Replaced "View As" button with public/private toggle (ver.q only) |
| `routes/notes/NewNote.tsx` | Default visibility based on `is_public` |
| `components/note/new-note-content/NewNoteContent.tsx` | Checkbox toggles between public/friends based on account type |
| `routes/responses/NewResponse.tsx` | Same visibility logic + ver.q checkbox UI |
| `i18n/locales/{en,ko}/translation.json` | Added translations |
