### PR TITLE
chore(account): rename VersionSwapRequest -> VersionSwitchRequest

### DIFF
--- a/adoorback/account/admin.py
+++ b/adoorback/account/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth import get_user_model
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 
-from account.models import FriendRequest, Interest, Persona, VersionSwapRequest
+from account.models import FriendRequest, Interest, Persona, VersionSwitchRequest
 
 User = get_user_model()
 
@@ -49,14 +49,14 @@ class UserAdmin(ImportExportModelAdmin):
     resource_class = UserResource
 
 
-class VersionSwapRequestResource(resources.ModelResource):
+class VersionSwitchRequestResource(resources.ModelResource):
 
     class Meta:
-        model = VersionSwapRequest
+        model = VersionSwitchRequest
 
 
-class VersionSwapRequestAdmin(ImportExportModelAdmin):
-    resource_class = VersionSwapRequestResource
+class VersionSwitchRequestAdmin(ImportExportModelAdmin):
+    resource_class = VersionSwitchRequestResource
     list_display = ['user', 'from_version', 'to_version', 'status', 'created_at', 'reason']
     list_filter = ['status', 'from_version', 'to_version']
     search_fields = ['user__username']
@@ -67,4 +67,4 @@ admin.site.register(User, UserAdmin)
 admin.site.register(FriendRequest, FriendRequestAdmin)
 admin.site.register(Interest, InterestAdmin)
 admin.site.register(Persona, PersonaAdmin)
-admin.site.register(VersionSwapRequest, VersionSwapRequestAdmin)
+admin.site.register(VersionSwitchRequest, VersionSwitchRequestAdmin)

--- a/adoorback/account/management/commands/process_version_switch.py
+++ b/adoorback/account/management/commands/process_version_switch.py
@@ -2,12 +2,12 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils import timezone
 
-from account.models import VersionSwapRequest
+from account.models import VersionSwitchRequest
 
 
 class Command(BaseCommand):
     help = (
-        'List, approve, or reject VersionSwapRequest entries.\n'
+        'List, approve, or reject VersionSwitchRequest entries.\n'
         '  list                — show pending requests\n'
         '  approve <REQ_ID>    — flip user.current_ver and mark approved\n'
         '  reject  <REQ_ID>    — mark rejected (user unchanged)\n'
@@ -17,7 +17,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('action', choices=['list', 'approve', 'reject'])
         parser.add_argument('request_id', nargs='?', type=int, default=None,
-                            help='VersionSwapRequest id (required for approve/reject)')
+                            help='VersionSwitchRequest id (required for approve/reject)')
         parser.add_argument('--include-user-group', action='store_true',
                             help='Also flip user_group when approving '
                                  '(only set this if research design needs it; off by default).')
@@ -38,7 +38,7 @@ class Command(BaseCommand):
             self._reject(req_id)
 
     def _list_pending(self):
-        qs = (VersionSwapRequest.objects
+        qs = (VersionSwitchRequest.objects
               .filter(status='pending')
               .select_related('user')
               .order_by('created_at'))
@@ -55,11 +55,11 @@ class Command(BaseCommand):
     def _approve(self, req_id, *, include_user_group):
         with transaction.atomic():
             try:
-                r = (VersionSwapRequest.objects
+                r = (VersionSwitchRequest.objects
                      .select_for_update()
                      .select_related('user')
                      .get(id=req_id))
-            except VersionSwapRequest.DoesNotExist:
+            except VersionSwitchRequest.DoesNotExist:
                 raise CommandError(f'Request #{req_id} not found')
 
             if r.status != 'pending':
@@ -67,7 +67,7 @@ class Command(BaseCommand):
             if r.user.current_ver != r.from_version:
                 raise CommandError(
                     f'User current_ver ({r.user.current_ver}) does not match '
-                    f'request from_version ({r.from_version}); refusing to swap.'
+                    f'request from_version ({r.from_version}); refusing to switch.'
                 )
 
             user = r.user
@@ -91,8 +91,8 @@ class Command(BaseCommand):
     def _reject(self, req_id):
         with transaction.atomic():
             try:
-                r = VersionSwapRequest.objects.select_for_update().get(id=req_id)
-            except VersionSwapRequest.DoesNotExist:
+                r = VersionSwitchRequest.objects.select_for_update().get(id=req_id)
+            except VersionSwitchRequest.DoesNotExist:
                 raise CommandError(f'Request #{req_id} not found')
             if r.status != 'pending':
                 raise CommandError(f'Request #{req_id} is already {r.status}')

--- a/adoorback/account/migrations/0059_rename_versionswaprequest_to_versionswitchrequest.py
+++ b/adoorback/account/migrations/0059_rename_versionswaprequest_to_versionswitchrequest.py
@@ -1,0 +1,43 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('account', '0058_versionswaprequest_and_more'),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            old_name='VersionSwapRequest',
+            new_name='VersionSwitchRequest',
+        ),
+        migrations.RemoveConstraint(
+            model_name='versionswitchrequest',
+            name='unique_pending_version_swap_request',
+        ),
+        migrations.AddConstraint(
+            model_name='versionswitchrequest',
+            constraint=models.UniqueConstraint(
+                condition=models.Q(('status', 'pending'), ('deleted__isnull', True)),
+                fields=('user',),
+                name='unique_pending_version_switch_request',
+            ),
+        ),
+        migrations.AlterField(
+            model_name='versionswitchrequest',
+            name='user',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='version_switch_requests',
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.RenameIndex(
+            model_name='versionswitchrequest',
+            new_name='account_ver_created_7033ae_idx',
+            old_name='account_ver_created_2c4819_idx',
+        ),
+    ]

--- a/adoorback/account/models.py
+++ b/adoorback/account/models.py
@@ -1171,7 +1171,7 @@ def provision_wit_admin_rooms(created, instance, **kwargs):
         return
 
 
-class VersionSwapRequest(AdoorTimestampedModel, SafeDeleteModel):
+class VersionSwitchRequest(AdoorTimestampedModel, SafeDeleteModel):
     STATUS_CHOICES = (
         ('pending', 'Pending'),
         ('approved', 'Approved'),
@@ -1179,7 +1179,7 @@ class VersionSwapRequest(AdoorTimestampedModel, SafeDeleteModel):
     )
 
     user = models.ForeignKey(
-        get_user_model(), related_name='version_swap_requests', on_delete=models.CASCADE)
+        get_user_model(), related_name='version_switch_requests', on_delete=models.CASCADE)
     from_version = models.CharField(max_length=20, choices=VERSION_CHOICES)
     to_version = models.CharField(max_length=20, choices=VERSION_CHOICES)
     reason = models.TextField(null=True, blank=True)
@@ -1195,7 +1195,7 @@ class VersionSwapRequest(AdoorTimestampedModel, SafeDeleteModel):
             models.UniqueConstraint(
                 fields=['user'],
                 condition=Q(status='pending') & Q(deleted__isnull=True),
-                name='unique_pending_version_swap_request'),
+                name='unique_pending_version_switch_request'),
         ]
         indexes = [
             models.Index(fields=['-created_at']),

--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -16,7 +16,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 
 from account.models import FriendRequest, BlockRec, Connection, AppSession, \
     VERSION_CHOICES, PERSONA_CHOICES, Interest, Persona, CustomChip, CHIP_CATEGORY_CHOICES, \
-    FriendEvaluation, RELATIONSHIP_TYPE_CHOICES, VersionSwapRequest
+    FriendEvaluation, RELATIONSHIP_TYPE_CHOICES, VersionSwitchRequest
 from adoorback.utils.alerts import send_msg_to_slack
 from adoorback.utils.exceptions import ExistingEmail, ExistingUsername
 from check_in.models import CheckIn
@@ -1090,15 +1090,15 @@ class CustomChipSerializer(serializers.ModelSerializer):
         fields = ['id', 'text', 'category']
 
 
-class VersionSwapRequestSerializer(serializers.ModelSerializer):
+class VersionSwitchRequestSerializer(serializers.ModelSerializer):
     class Meta:
-        model = VersionSwapRequest
+        model = VersionSwitchRequest
         fields = ['id', 'reason', 'from_version', 'to_version', 'status', 'created_at']
         read_only_fields = ['id', 'from_version', 'to_version', 'status', 'created_at']
 
     def validate(self, attrs):
         user = self.context['request'].user
-        if VersionSwapRequest.objects.filter(user=user, status='pending').exists():
+        if VersionSwitchRequest.objects.filter(user=user, status='pending').exists():
             raise serializers.ValidationError(
-                {'detail': 'A pending version swap request already exists.'})
+                {'detail': 'A pending version switch request already exists.'})
         return attrs

--- a/adoorback/account/urls.py
+++ b/adoorback/account/urls.py
@@ -111,7 +111,7 @@ urlpatterns = [
     path("app-sessions/end/", views.EndSession.as_view(), name="end_session"),
     path("app-sessions/touch/", views.TouchSession.as_view(), name="touch_session"),
 
-    # Version Swap Request
-    path('version-swap-request/', views.VersionSwapRequestCreate.as_view(), name='version-swap-request-create'),
-    path('version-swap-request/me/', views.CurrentUserVersionSwapRequest.as_view(), name='current-user-version-swap-request'),
+    # Version Switch Request
+    path('version-switch-request/', views.VersionSwitchRequestCreate.as_view(), name='version-switch-request-create'),
+    path('version-switch-request/me/', views.CurrentUserVersionSwitchRequest.as_view(), name='current-user-version-switch-request'),
 ]

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -38,7 +38,7 @@ from safedelete.models import SOFT_DELETE_CASCADE
 from .email import email_manager
 from .models import Subscription, Connection, AppSession, DiscoverFeed, DiscoverFeedMusic, Persona, Interest
 from custom_fcm.models import CustomFCMDevice
-from account.models import FriendRequest, BlockRec, CustomChip, FriendEvaluation, VersionSwapRequest
+from account.models import FriendRequest, BlockRec, CustomChip, FriendEvaluation, VersionSwitchRequest
 from account.serializers import (CurrentUserSerializer, CurrentUserSignupSerializer, \
                                  UserFriendRequestCreateSerializer, UserFriendRequestUpdateSerializer, \
                                  UserFriendshipStatusSerializer, \
@@ -51,7 +51,7 @@ from account.serializers import (CurrentUserSerializer, CurrentUserSignupSeriali
                                  UserMinimalSerializer, \
                                  UserInterestUpdateSerializer, UserPersonaUpdateSerializer, \
                                  InterestSerializer, PersonaSerializer, viewer_sees_check_in_component,
-                                 VersionSwapRequestSerializer,
+                                 VersionSwitchRequestSerializer,
                                  RECENT_POST_WINDOW)
 from account.view_as import apply_profile_view_as, parse_view_as, resolve_public_proxy_viewer, resolve_shadow_viewer
 from adoorback.utils.content_types import get_generic_relation_type, get_friend_request_type
@@ -3493,9 +3493,9 @@ class TmiPlaceholder(APIView):
             return Response({'placeholder': placeholder})
 
 
-class VersionSwapRequestCreate(generics.CreateAPIView):
-    queryset = VersionSwapRequest.objects.all()
-    serializer_class = VersionSwapRequestSerializer
+class VersionSwitchRequestCreate(generics.CreateAPIView):
+    queryset = VersionSwitchRequest.objects.all()
+    serializer_class = VersionSwitchRequestSerializer
     permission_classes = [IsAuthenticated]
 
     def get_exception_handler(self):
@@ -3509,13 +3509,13 @@ class VersionSwapRequestCreate(generics.CreateAPIView):
         serializer.save(user=user, from_version=from_version, to_version=to_version)
 
 
-class CurrentUserVersionSwapRequest(APIView):
+class CurrentUserVersionSwitchRequest(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
-        pending = VersionSwapRequest.objects.filter(
+        pending = VersionSwitchRequest.objects.filter(
             user=request.user, status='pending').first()
         if pending is None:
             return Response({'pending': None}, status=status.HTTP_200_OK)
-        serializer = VersionSwapRequestSerializer(pending, context={'request': request})
+        serializer = VersionSwitchRequestSerializer(pending, context={'request': request})
         return Response({'pending': serializer.data}, status=status.HTTP_200_OK)


### PR DESCRIPTION
## Summary
- "Switch versions" reads more naturally than "swap versions" to native English speakers, so unify naming end-to-end.
- Rename model, serializer, views, admin, URL paths (`/user/version-switch-request/`), and management command (`process_version_switch`).
- Migration uses `RenameModel` + constraint/index rename to preserve any existing rows.

## Pairs with
Frontend PR (must merge together — API URL path changes): chore/version-switch-rename

## Test plan
- [ ] `python manage.py check` clean
- [ ] `python manage.py makemigrations --check` clean
- [ ] `sqlmigrate account 0059` SQL: `ALTER TABLE` rename + constraint/index rename (verified locally)
- [ ] After deploy, run migrations against staging and confirm any pending request rows survive
- [ ] `python manage.py process_version_switch list` works