### PR TITLE
chore(surveys): seed_question_type_demos for QA verification

### DIFF
--- a/adoorback/surveys/fixtures/demo_question_types.yaml
+++ b/adoorback/surveys/fixtures/demo_question_types.yaml
@@ -1,0 +1,111 @@
+# Demo fixture — one survey per question type, for QA verification of every
+# input UI and every result renderer.
+#
+# Run via:  python manage.py seed_question_type_demos --email <your-email>
+# (the orchestrator command loads this fixture, schedules each demo on a past
+# daily slot, seeds mock responses, and seeds the viewer's response too so
+# /surveys/<slug>/results renders immediately).
+
+- slug: demo_likert
+  type: likert_5
+  title:
+    en: "Demo · Likert (multi-question)"
+    ko: "데모 · 리커트 (다문항)"
+  description:
+    en: "Five-item likert. Aggregates as a single histogram of summed reverse-aware scores."
+    ko: "5문항 리커트. 역점수 합산 히스토그램으로 집계됩니다."
+  interpretation:
+    en: "Higher scores = stronger positive sentiment."
+    ko: "점수가 높을수록 긍정적입니다."
+  friend_visible: true
+  results_hidden: false
+  questions:
+    - order: 1
+      prompt: { en: "I felt productive today.", ko: "오늘 능률이 올랐다." }
+      low_label: { en: "Strongly disagree", ko: "매우 그렇지 않다" }
+      high_label: { en: "Strongly agree", ko: "매우 그렇다" }
+      reverse_scored: false
+    - order: 2
+      prompt: { en: "I felt overwhelmed today.", ko: "오늘 압도되는 기분이었다." }
+      low_label: { en: "Strongly disagree", ko: "매우 그렇지 않다" }
+      high_label: { en: "Strongly agree", ko: "매우 그렇다" }
+      reverse_scored: true
+    - order: 3
+      prompt: { en: "I felt connected to people.", ko: "사람들과 연결된 기분이었다." }
+      low_label: { en: "Strongly disagree", ko: "매우 그렇지 않다" }
+      high_label: { en: "Strongly agree", ko: "매우 그렇다" }
+      reverse_scored: false
+
+- slug: demo_single_choice
+  type: single_choice
+  title:
+    en: "Demo · Single choice"
+    ko: "데모 · 단일 선택"
+  description:
+    en: "Pick exactly one. Aggregates as per-option counts."
+    ko: "하나만 선택. 옵션별 응답 수로 집계됩니다."
+  friend_visible: true
+  results_hidden: false
+  questions:
+    - order: 1
+      prompt: { en: "What's your most-used app today?", ko: "오늘 가장 많이 쓴 앱은?" }
+      options:
+        - { order: 1, value: 1, label: { en: "Instagram",   ko: "인스타그램" } }
+        - { order: 2, value: 2, label: { en: "TikTok",      ko: "틱톡" } }
+        - { order: 3, value: 3, label: { en: "X / Twitter", ko: "X (트위터)" } }
+        - { order: 4, value: 4, label: { en: "YouTube",     ko: "유튜브" } }
+        - { order: 5, value: 5, label: { en: "Other",       ko: "기타" } }
+
+- slug: demo_multi_choice
+  type: multi_choice
+  title:
+    en: "Demo · Multi choice"
+    ko: "데모 · 다중 선택"
+  description:
+    en: "Pick any that apply. Aggregates as per-option counts (each pick adds 1)."
+    ko: "해당하는 것 모두 선택. 옵션별 응답 수로 집계됩니다."
+  friend_visible: true
+  results_hidden: false
+  questions:
+    - order: 1
+      prompt: { en: "What did you do for fun today?", ko: "오늘 즐거움을 위해 한 일은?" }
+      options:
+        - { order: 1, value: 1, label: { en: "Listened to music",  ko: "음악 감상" } }
+        - { order: 2, value: 2, label: { en: "Watched something",  ko: "영상 시청" } }
+        - { order: 3, value: 3, label: { en: "Went outside",       ko: "야외 활동" } }
+        - { order: 4, value: 4, label: { en: "Read",               ko: "독서" } }
+        - { order: 5, value: 5, label: { en: "Hung out with friends", ko: "친구들과 시간" } }
+        - { order: 6, value: 6, label: { en: "None of the above",  ko: "해당 없음" } }
+
+- slug: demo_free_text
+  type: free_text
+  title:
+    en: "Demo · Free text"
+    ko: "데모 · 자유 응답"
+  description:
+    en: "Open response. Aggregates as a wordcloud (tokens with count ≥ 3)."
+    ko: "자유 응답. 워드클라우드(빈도 3 이상)로 집계됩니다."
+  friend_visible: true
+  results_hidden: false
+  questions:
+    - order: 1
+      prompt: { en: "One word that describes today?", ko: "오늘을 한 단어로?" }
+
+- slug: demo_slider
+  type: slider
+  title:
+    en: "Demo · Slider"
+    ko: "데모 · 슬라이더"
+  description:
+    en: "Pick a number on a 0–100 scale. Aggregates as a 10-bin histogram with mean and median."
+    ko: "0–100 척도에서 숫자 선택. 10개 구간 히스토그램(평균/중앙값 포함)으로 집계됩니다."
+  friend_visible: true
+  results_hidden: false
+  questions:
+    - order: 1
+      prompt: { en: "How are you feeling right now?", ko: "지금 기분이 어떠세요?" }
+      low_label: { en: "Terrible", ko: "끔찍해요" }
+      high_label: { en: "Couldn't be better", ko: "더할 나위 없이 좋아요" }
+      slider_min_value: 0
+      slider_max_value: 100
+      result_kind: slider_histogram

--- a/adoorback/surveys/fixtures/mock_test_today.yaml
+++ b/adoorback/surveys/fixtures/mock_test_today.yaml
@@ -1,0 +1,40 @@
+# One-off "survey of the day" content for QA testing.
+# Loaded + scheduled via:
+#   python manage.py load_surveys adoorback/surveys/fixtures/mock_test_today.yaml
+#   python manage.py seed_survey_mock_data --email <dev-email> --today-slug mock_test_2026q2
+#
+# The --today-slug flag creates (or re-points) the daily ScheduledSurvey for
+# today to this survey, so it shows up on /share as Survey of the Day.
+
+- slug: mock_test_2026q2
+  title:
+    en: "quick mock survey"
+    ko: "간단 모의 설문"
+  description:
+    en: "short survey"
+    ko: "짧은 설문"
+  friend_visible: false
+  results_hidden: false
+  questions:
+    - order: 1
+      type: slider
+      prompt:
+        en: "How are you feeling today?"
+        ko: "오늘 기분이 어떤가요?"
+      low_label: { en: "Terrible", ko: "끔찍해요" }
+      high_label: { en: "Couldn't be better", ko: "더할 나위 없이 좋아요" }
+      slider_min_value: 0
+      slider_max_value: 100
+      result_kind: slider_histogram
+    - order: 2
+      type: single_choice
+      prompt:
+        en: "What's the weather like where you are right now?"
+        ko: "지금 있는 곳의 날씨는 어때요?"
+      result_kind: option_counts
+      options:
+        - { order: 1, value: 1, label: { en: "☀️ Sunny", ko: "☀️ 맑음" } }
+        - { order: 2, value: 2, label: { en: "⛅ Partly cloudy", ko: "⛅ 구름 조금" } }
+        - { order: 3, value: 3, label: { en: "☁️ Cloudy", ko: "☁️ 흐림" } }
+        - { order: 4, value: 4, label: { en: "🌧️ Rainy", ko: "🌧️ 비" } }
+        - { order: 5, value: 5, label: { en: "❄️ Snowy / Other", ko: "❄️ 눈 / 기타" } }

--- a/adoorback/surveys/management/commands/seed_question_type_demos.py
+++ b/adoorback/surveys/management/commands/seed_question_type_demos.py
@@ -1,0 +1,154 @@
+"""Seed five demo surveys (one per question type) on past daily slots so a dev
+can verify every input UI and every result renderer end-to-end.
+
+Loads surveys/fixtures/demo_question_types.yaml, schedules each demo on a
+past daily slot (today-1 .. today-5), seeds mock-user responses via
+seed_survey_mock_data, and seeds a viewer response per demo so
+/surveys/<slug>/results unlocks immediately for the dev user.
+
+Usage:
+    python manage.py seed_question_type_demos --email <your-dev-email>
+
+Idempotent on re-run (load_surveys is upsert; ScheduledSurvey uses
+update_or_create on (cadence, sequence_index); viewer response insert is
+guarded by .exists()).
+"""
+from __future__ import annotations
+
+import random
+from datetime import date, timedelta
+from pathlib import Path
+
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from surveys.models import (
+    CADENCE_DAILY, FREE_TEXT, LIKERT_5, MULTI_CHOICE, SINGLE_CHOICE, SLIDER,
+    ScheduledSurvey, Survey, SurveyAnswer, SurveyResponse,
+)
+
+
+User = get_user_model()
+
+
+DEMO_SLUGS = [
+    'demo_likert',
+    'demo_single_choice',
+    'demo_multi_choice',
+    'demo_free_text',
+    'demo_slider',
+]
+
+# sequence_index range reserved for demos. Picked 1000+ to stay clear of the
+# real study schedule (which uses 1..28 for daily, etc.).
+DEMO_SEQUENCE_BASE = 1000
+
+# Mock free-text answers — duplicated so the wordcloud's k-anonymity threshold
+# (MIN_TOKEN_FREQUENCY = 3) clears for at least a few tokens.
+_FREE_TEXT_SAMPLES = [
+    'good',
+    'tired',
+    'meh',
+    'productive',
+    'overwhelmed',
+    'happy',
+    'stressed',
+    'energetic',
+    'calm',
+    'okay honestly',
+]
+
+
+class Command(BaseCommand):
+    help = (
+        'Seed demo surveys (one per question type) on past daily slots + mock '
+        'responses + viewer response so /surveys/<slug>/results renders.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--email', required=True,
+            help="Dev user email — viewer gets responses too so results pages render without manual submission.",
+        )
+        parser.add_argument(
+            '--seed', type=int, default=42,
+            help='Random seed for deterministic mock answers.',
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **opts):
+        viewer_email = opts['email']
+        try:
+            viewer = User.objects.get(email=viewer_email)
+        except User.DoesNotExist:
+            raise CommandError(f'No user with email {viewer_email!r}')
+
+        # 1. Load fixture (idempotent; re-runs upsert by slug).
+        fixture_path = Path(__file__).resolve().parents[2] / 'fixtures' / 'demo_question_types.yaml'
+        if not fixture_path.exists():
+            raise CommandError(f'Demo fixture not found at {fixture_path}')
+        self.stdout.write(f'Loading {fixture_path} ...')
+        call_command('load_surveys', str(fixture_path), '--replace-questions')
+
+        # 2. Schedule each demo on a past daily slot (today-1 backwards).
+        today = date.today()
+        for i, slug in enumerate(DEMO_SLUGS, start=1):
+            schedule_date = today - timedelta(days=i)
+            survey = Survey.objects.get(slug=slug)
+            seq = DEMO_SEQUENCE_BASE + i
+            ScheduledSurvey.objects.update_or_create(
+                cadence=CADENCE_DAILY, sequence_index=seq,
+                defaults={
+                    'survey': survey,
+                    'window_start': schedule_date,
+                    'window_end': schedule_date,
+                    'allow_late': False,
+                },
+            )
+            self.stdout.write(f'  scheduled {slug} on {schedule_date} (seq={seq})')
+
+        # 3. Seed mock users + responses across ALL surveys (covers demos too).
+        self.stdout.write('Seeding mock users + responses via seed_survey_mock_data ...')
+        call_command('seed_survey_mock_data', email=viewer_email, seed=opts['seed'])
+
+        # 4. Seed a viewer response per demo so the dev user can hit
+        #    /surveys/<slug>/results without first submitting through the UI.
+        rng = random.Random(opts['seed'] + 1)  # different seed branch from mock-user seeding
+        for slug in DEMO_SLUGS:
+            survey = Survey.objects.get(slug=slug)
+            if SurveyResponse.objects.filter(user=viewer, survey=survey).exists():
+                self.stdout.write(f'  viewer already responded to {slug}, skipping')
+                continue
+            response = SurveyResponse.objects.create(user=viewer, survey=survey)
+            for question in survey.questions.order_by('order'):
+                value = self._mock_value(question, rng)
+                SurveyAnswer.objects.create(response=response, question=question, value=value)
+            self.stdout.write(f'  seeded viewer response for {slug}')
+
+        self.stdout.write(self.style.SUCCESS(
+            f'Done. Open /surveys/daily-archive (or /surveys/<slug>/results) as {viewer.username}.'
+        ))
+
+    @staticmethod
+    def _mock_value(question, rng: random.Random):
+        qtype = question.type
+        if qtype == LIKERT_5:
+            return rng.randint(1, 5)
+        if qtype == SINGLE_CHOICE:
+            opts = list(question.options.values_list('value', flat=True))
+            return rng.choice(opts) if opts else 0
+        if qtype == MULTI_CHOICE:
+            opts = list(question.options.values_list('value', flat=True))
+            if not opts:
+                return []
+            n_pick = rng.randint(1, len(opts))
+            return rng.sample(opts, k=n_pick)
+        if qtype == FREE_TEXT:
+            return rng.choice(_FREE_TEXT_SAMPLES)
+        if qtype == SLIDER:
+            lo = question.slider_min_value if question.slider_min_value is not None else 0
+            hi = question.slider_max_value if question.slider_max_value is not None else 100
+            return rng.randint(lo, hi)
+        return rng.randint(1, 5)  # safe fallback

--- a/adoorback/surveys/management/commands/seed_survey_mock_data.py
+++ b/adoorback/surveys/management/commands/seed_survey_mock_data.py
@@ -90,6 +90,10 @@ def _seed_response(user, survey, rng: random.Random) -> None:
             value = rng.sample(opts, k=min(n_pick, len(opts))) if opts else []
         elif qtype == 'free_text':
             value = rng.choice(_FREE_TEXT_SAMPLES)
+        elif qtype == 'slider':
+            lo = question.slider_min_value if question.slider_min_value is not None else 0
+            hi = question.slider_max_value if question.slider_max_value is not None else 100
+            value = rng.randint(lo, hi)
         else:
             value = _random_likert(rng)
         SurveyAnswer.objects.create(response=response, question=question, value=value)


### PR DESCRIPTION
## Summary

One-shot management command that populates the dev DB with five demo surveys (one per question type) so devs can verify every input UI and every result renderer end-to-end without manually authoring fixtures or submitting through the UI.

```
python manage.py seed_question_type_demos --email <dev-user-email>
```

What it does:
1. Loads `surveys/fixtures/demo_question_types.yaml` (5 surveys: likert_5, single_choice, multi_choice, free_text, slider)
2. Schedules each demo on a past daily slot (today-1 .. today-5) with `sequence_index=1001..1005` (clear of the real study schedule's 1-28)
3. Calls existing `seed_survey_mock_data` to populate mock users + responses across all surveys
4. Adds a viewer response per demo so `/surveys/<slug>/results` unlocks immediately

Bonus:
- Patched `seed_survey_mock_data._seed_response()` to handle `'slider'` question type (random int in `[slider_min_value, slider_max_value]`). Previously fell through to a 1-5 likert value — worked but unrepresentative.

## Test plan

- [x] Ran locally as `adoor_1` (`edward71@example.net`)
- [x] All 4 renderers verified at 393px viewport:
  - `slider_histogram` — 10 bars, viewer's bin highlighted in primary purple, mean + median, three buckets (Everyone n=21, Friends n=14, Close Friends n=6)
  - `aggregated_likert` — score distribution 3-15 (3 questions × 1-5), viewer score highlighted, percentile message
  - `option_counts` (single_choice) — per-option counts, viewer's pick highlighted in purple
  - `option_counts` (multi_choice) — multiple selected options highlighted in purple
  - `wordcloud` — token sizes by frequency, viewer's token highlighted, k-anonymity footer ("22 words said by fewer than 3 people are hidden..."), friend buckets correctly suppressed
- [x] Re-running the command is idempotent (load_surveys upserts, ScheduledSurvey uses update_or_create on (cadence, sequence_index), viewer response insert guarded by .exists())

## Out of scope

- This is a dev/QA-only tool. The fixture is named `demo_question_types.yaml` and the slugs (`demo_*`) are obviously demo content. Don't run on prod unless you're intentionally seeding demo data for QA — the mock users will end up in your prod DB.