### PR TITLE
fix(surveys): enforce daily window — hide future, expire past

### DIFF
--- a/adoorback/surveys/tests_views_archive.py
+++ b/adoorback/surveys/tests_views_archive.py
@@ -7,10 +7,15 @@ from surveys._test_helpers import make_likert_survey, make_user, respond
 
 
 class PastSurveysViewTests(APITestCase):
-    def test_returns_descending_dates(self):
+    """Daily archive — only surfaces dailies the user answered, on-or-before
+    today. Future dailies and past unanswered dailies are hidden."""
+
+    def test_returns_only_answered_dailies_descending(self):
         viewer = make_user('viewer')
         s1 = make_likert_survey('s1', schedule_date=datetime.date.today() - datetime.timedelta(days=2))
         s2 = make_likert_survey('s2', schedule_date=datetime.date.today() - datetime.timedelta(days=1))
+        respond(viewer, s1, [3, 3])
+        respond(viewer, s2, [4, 4])
         self.client.force_authenticate(user=viewer)
         r = self.client.get('/api/surveys/past/')
         self.assertEqual(r.status_code, status.HTTP_200_OK)
@@ -27,8 +32,6 @@ class PastSurveysViewTests(APITestCase):
         # s_today: user answered, day is today → not unlocked yet
         s_today = make_likert_survey('s_today', schedule_date=datetime.date.today())
         respond(viewer, s_today, [4, 2])
-        # s_unanswered: scheduled in the past, user did not answer
-        make_likert_survey('s_unans', schedule_date=datetime.date.today() - datetime.timedelta(days=1))
 
         self.client.force_authenticate(user=viewer)
         r = self.client.get('/api/surveys/past/')
@@ -38,5 +41,25 @@ class PastSurveysViewTests(APITestCase):
         self.assertTrue(slugs['s_old']['results_unlocked'])
         self.assertTrue(slugs['s_today']['user_answered'])
         self.assertFalse(slugs['s_today']['results_unlocked'])
-        self.assertFalse(slugs['s_unans']['user_answered'])
-        self.assertFalse(slugs['s_unans']['results_unlocked'])
+
+    def test_unanswered_past_dailies_hidden(self):
+        """Past dailies the user didn't answer don't show up — they're
+        un-submittable and have no results to view."""
+        viewer = make_user('viewer')
+        make_likert_survey('s_unans', schedule_date=datetime.date.today() - datetime.timedelta(days=1))
+        self.client.force_authenticate(user=viewer)
+        r = self.client.get('/api/surveys/past/')
+        self.assertEqual(r.status_code, status.HTTP_200_OK)
+        self.assertEqual(r.json()['results'], [])
+
+    def test_future_dailies_hidden(self):
+        """Future-scheduled dailies aren't exposed in advance, even if other
+        users somehow answered them already."""
+        viewer = make_user('viewer')
+        make_likert_survey(
+            's_future',
+            schedule_date=datetime.date.today() + datetime.timedelta(days=3),
+        )
+        self.client.force_authenticate(user=viewer)
+        r = self.client.get('/api/surveys/past/')
+        self.assertEqual(r.json()['results'], [])

--- a/adoorback/surveys/tests_views_submit.py
+++ b/adoorback/surveys/tests_views_submit.py
@@ -37,3 +37,33 @@ class SurveySubmitViewTests(APITestCase):
         self.client.force_authenticate(user=viewer)
         r = self.client.post('/api/surveys/nonexistent/responses/', {'answers': []}, format='json')
         self.assertEqual(r.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_expired_daily_returns_410(self):
+        """Daily window closed and allow_late=False → submission rejected."""
+        import datetime
+        viewer = make_user('viewer')
+        s = make_likert_survey('expired', schedule_date=datetime.date.today() - datetime.timedelta(days=1))
+        self.client.force_authenticate(user=viewer)
+        questions = list(s.questions.order_by('order'))
+        payload = {'answers': [
+            {'question_id': questions[0].id, 'value': 4},
+            {'question_id': questions[1].id, 'value': 2},
+        ]}
+        r = self.client.post(f'/api/surveys/{s.slug}/responses/', payload, format='json')
+        self.assertEqual(r.status_code, status.HTTP_410_GONE)
+        self.assertEqual(SurveyResponse.objects.filter(user=viewer, survey=s).count(), 0)
+
+    def test_not_yet_open_returns_403(self):
+        """Future-scheduled survey → submission rejected."""
+        import datetime
+        viewer = make_user('viewer')
+        s = make_likert_survey('future', schedule_date=datetime.date.today() + datetime.timedelta(days=3))
+        self.client.force_authenticate(user=viewer)
+        questions = list(s.questions.order_by('order'))
+        payload = {'answers': [
+            {'question_id': questions[0].id, 'value': 4},
+            {'question_id': questions[1].id, 'value': 2},
+        ]}
+        r = self.client.post(f'/api/surveys/{s.slug}/responses/', payload, format='json')
+        self.assertEqual(r.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(SurveyResponse.objects.filter(user=viewer, survey=s).count(), 0)

--- a/adoorback/surveys/views.py
+++ b/adoorback/surveys/views.py
@@ -91,6 +91,27 @@ class SurveyResponseSubmitView(APIView):
             return Response(
                 {'detail': 'Already submitted.'}, status=status.HTTP_409_CONFLICT
             )
+        # Reject submissions to scheduled surveys whose window has already
+        # closed without late-submission allowance (matches the bucketing
+        # rule's "expired hidden" semantics — daily is the canonical case).
+        today = date.today()
+        if ScheduledSurvey.objects.filter(
+            survey=survey, allow_late=False, window_end__lt=today,
+        ).exists():
+            return Response(
+                {'detail': 'This survey has expired and can no longer be answered.'},
+                status=status.HTTP_410_GONE,
+            )
+        # Reject submissions to scheduled surveys whose window hasn't opened
+        # yet — direct-URL access to a future-dated survey shouldn't bypass
+        # the index/UI gating.
+        if ScheduledSurvey.objects.filter(
+            survey=survey, window_start__gt=today,
+        ).exists():
+            return Response(
+                {'detail': 'This survey is not yet open for responses.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         ser = SurveyResponseInputSerializer(data=request.data)
         ser.is_valid(raise_exception=True)
         try:
@@ -180,15 +201,26 @@ class SurveyResultsView(APIView):
 
 
 class PastSurveysView(APIView):
-    """Daily-only archive. Powers the 'Daily check-ins (N completed)' page —
-    a flat list of daily ScheduledSurvey rows newest-first.
+    """Daily-only archive — only rows the user has answered, scheduled
+    on-or-before today. Future dailies are not exposed; past unanswered
+    dailies are hidden because they can no longer be submitted (allow_late=
+    False on daily) and have no results to view.
     """
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        today = date.today()
+        answered_survey_ids = list(
+            SurveyResponse.objects.filter(user=request.user).values_list('survey_id', flat=True)
+        )
         qs = (
             ScheduledSurvey.objects
-            .filter(cadence=CADENCE_DAILY, survey__results_hidden=False)
+            .filter(
+                cadence=CADENCE_DAILY,
+                survey__results_hidden=False,
+                window_start__lte=today,
+                survey_id__in=answered_survey_ids,
+            )
             .select_related('survey')
             .order_by('-window_start')
         )


### PR DESCRIPTION
## Summary

Triggered by [#976](https://github.com/ssm0318/WhoamI-Today-backend/pull/976)'s demo seed exposing the entire May 3-30 daily schedule in `/surveys/daily-archive` — these dailies were always being returned by the API; the small dev DB just hid the bug. Fixes two related correctness gaps:

1. **Daily archive filter.** `PastSurveysView` (`/api/surveys/past/`) used to return every daily `ScheduledSurvey` regardless of date or answer state. Now filters to `cadence='daily'` AND `window_start <= today` AND user has answered. Future-scheduled dailies aren't exposed in advance; past unanswered dailies are hidden because they have no results to view and can no longer be submitted.

2. **Submit view enforcement.** `SurveyResponseSubmitView` accepted submissions to any survey regardless of its scheduled window. Now:
   - Returns **410 GONE** when a `ScheduledSurvey` for this survey has `window_end < today` and `allow_late=False` (covers daily; generalizes to any future hard-window cadence).
   - Returns **403 FORBIDDEN** when `window_start > today` (window not yet open).

Direct-URL access to `/surveys/<slug>/answer` can no longer bypass index/UI gating.

## Test plan

- [x] `tests_views_archive` rewritten for the answered-only contract — 4 tests covering descending order, answered/unlocked flags, unanswered-past hidden, future hidden
- [x] `tests_views_submit` gains `test_expired_daily_returns_410` and `test_not_yet_open_returns_403`
- [x] Full surveys + account suite passes (64 tests)
- [x] Verified locally: `/surveys/daily-archive` now shows only the 5 demo dailies (Apr 26-30, all answered) instead of all 33 daily slots