### PR TITLE
fix(surveys): keep Survey of the Day card after answering

### DIFF
--- a/adoorback/surveys/scheduling.py
+++ b/adoorback/surveys/scheduling.py
@@ -25,8 +25,12 @@ def _annotate_user_response(qs, user):
 def get_today_daily(user):
     """Return today's daily ScheduledSurvey for `user`, or None.
 
-    Filters on user_answered=False so the SurveyOfTheDay card on /share
-    disappears once the user has answered today's daily.
+    Returns the row regardless of whether the user has answered — the
+    SurveyOfTheDay card on /share renders an answered-state UI ("Done /
+    View results") once user_has_responded flips true. Hiding the card
+    after answering led to confusion ("did I do it? was it submitted?")
+    and a stale-cache window where users could navigate back into the
+    answer form and hit a 409.
     """
     today = date.today()
     return (
@@ -36,7 +40,6 @@ def get_today_daily(user):
             ),
             user,
         )
-        .filter(user_answered=False)
         .select_related('survey')
         .first()
     )

--- a/adoorback/surveys/tests_scheduling.py
+++ b/adoorback/surveys/tests_scheduling.py
@@ -34,7 +34,8 @@ class SchedulingTests(TestCase):
         self.assertIsNotNone(result)
         self.assertEqual(result.survey, s)
 
-    def test_today_daily_returns_none_when_answered(self):
+    def test_today_daily_returns_survey_even_when_answered(self):
+        """Card stays after answering so the user can see Done / View results."""
         s = self._survey('daily_base')
         ScheduledSurvey.objects.create(
             survey=s, cadence=CADENCE_DAILY,
@@ -42,7 +43,10 @@ class SchedulingTests(TestCase):
             allow_late=False, sequence_index=1,
         )
         SurveyResponse.objects.create(user=self.user, survey=s)
-        self.assertIsNone(get_today_daily(self.user))
+        result = get_today_daily(self.user)
+        self.assertIsNotNone(result)
+        self.assertEqual(result.survey, s)
+        self.assertTrue(result.user_answered)
 
     def test_today_daily_returns_none_when_not_today(self):
         s = self._survey('daily_base')


### PR DESCRIPTION
## Summary

Triggered by user feedback: after answering today's daily, the card disappeared from `/share` with no acknowledgement, and a stale-cache window briefly let users navigate back into `/surveys/<slug>/answer` and hit a 409.

Drop the `user_answered=False` filter from `get_today_daily`. The card now stays visible after submission, and the existing `user_has_responded` branch in `SurveyOfTheDay.tsx` (which renders "Thanks! Results available tomorrow." + a "View results" button) is finally reachable. No way to re-attempt — the answer button is replaced with a results link.

Companion to frontend [fix/surveys-scrollable-pages](https://github.com/ssm0318/WhoamI-Today-frontend/pull/1292) which adds a Done button on `/results` so the user can exit cleanly.

## Test plan

- [x] `tests_scheduling.test_today_daily_returns_survey_even_when_answered` replaces the old `_returns_none_when_answered` — asserts the row is returned with `user_answered=True` annotated
- [x] All scheduling tests pass (11)
- [x] All today-view tests pass (3)
- [x] Verified locally in browser: card stays after answering with "Thanks! Results available tomorrow." + "View results" button