### PR TITLE
fix(chat): bootstrap 5 system superusers + chat rooms automatically

### DIFF
--- a/adoorback/chat/management/commands/bootstrap_system_users.py
+++ b/adoorback/chat/management/commands/bootstrap_system_users.py
@@ -1,0 +1,101 @@
+"""Bootstrap WhoamI system accounts and provision their chat infrastructure.
+
+Idempotent. Designed to run automatically after `migrate` (see start.sh) so a
+fresh DB ends up with all 5 system accounts present, friended, and connected
+to every regular user via the WIT-Admin / wit_bot rooms.
+
+The 5 system accounts:
+    wit_admin   — support inbox identity
+    wit_bot     — system bot peer
+    jaewon      — operator/replier (the only operator allowed to reply/blast)
+    koyrkr      — operator/observer
+    njs         — operator/observer
+
+Newly-created system rows get is_superuser=True, is_staff=True, and a default
+password (env: SYSTEM_USER_DEFAULT_PASSWORD, fallback 'Adoor2020:)' for dev).
+Existing rows are left untouched — no flag upgrades, no password resets.
+"""
+import os
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from chat.wit_admin import (
+    OPERATOR_OBSERVER_EMAILS,
+    OPERATOR_REPLIER_EMAIL,
+    WIT_ADMIN_EMAIL,
+    WIT_ADMIN_USERNAME,
+    ensure_blast_rooms,
+    ensure_system_connections,
+    ensure_wit_admin_user,
+    provision_user_rooms,
+    regular_recipients,
+)
+from chat.wit_bot import (
+    WIT_BOT_EMAIL,
+    WIT_BOT_USERNAME,
+    ensure_wit_bot_room,
+    ensure_wit_bot_user,
+)
+
+
+DEFAULT_PASSWORD = 'Adoor2020:)'
+
+
+class Command(BaseCommand):
+    help = (
+        "Idempotently create the 5 WhoamI system accounts as superusers, "
+        "friend them with each other, and provision WIT-Admin + wit_bot chat "
+        "rooms for every regular user."
+    )
+
+    def handle(self, *args, **options):
+        self._create_system_users()
+        ensure_wit_admin_user()
+        ensure_wit_bot_user()
+        ensure_blast_rooms()
+        ensure_system_connections()
+
+        users = regular_recipients()
+        total = users.count()
+        for i, user in enumerate(users.iterator(chunk_size=500), 1):
+            provision_user_rooms(user)
+            ensure_wit_bot_room(user)
+            if i % 100 == 0:
+                self.stdout.write(f"  ... provisioned {i}/{total}")
+
+        self.stdout.write(self.style.SUCCESS(
+            f"Bootstrapped system users; provisioned chat rooms for {total} regular users."
+        ))
+
+    @transaction.atomic
+    def _create_system_users(self):
+        """Create any missing system rows as superusers. Skip rows that exist."""
+        User = get_user_model()
+        password = os.environ.get('SYSTEM_USER_DEFAULT_PASSWORD', DEFAULT_PASSWORD)
+
+        # (username, email) — operators first, then bots. Bots don't have to be
+        # superusers for the chat flow itself, but the user-stated requirement
+        # is that all 5 are superusers.
+        specs = [
+            ('jaewon', OPERATOR_REPLIER_EMAIL),
+            ('koyrkr', OPERATOR_OBSERVER_EMAILS[0]),
+            ('njs', OPERATOR_OBSERVER_EMAILS[1]),
+            (WIT_ADMIN_USERNAME, WIT_ADMIN_EMAIL),
+            (WIT_BOT_USERNAME, WIT_BOT_EMAIL),
+        ]
+
+        for username, email in specs:
+            if User.all_objects.filter(email=email).exists():
+                self.stdout.write(f"  - {username}: row with email {email} already exists; leaving as-is.")
+                continue
+            if User.all_objects.filter(username=username).exists():
+                self.stdout.write(f"  - {username}: row with username already exists; leaving as-is.")
+                continue
+            User.objects.create_superuser(
+                username=username,
+                email=email,
+                password=password,
+            )
+            self.stdout.write(f"  + Created superuser: {username} ({email})")

--- a/start.sh
+++ b/start.sh
@@ -10,5 +10,11 @@ if [ -n "$DJANGO_SUPERUSER_USERNAME" ] && [ -n "$DJANGO_SUPERUSER_EMAIL" ] && [ 
   echo "Superuser created successfully!"
 fi
 
+# Bootstrap WhoamI system accounts (wit_admin, wit_bot, jaewon, koyrkr, njs)
+# and provision their chat rooms. Idempotent; safe to re-run.
+echo "Bootstrapping system users and chat rooms..."
+python manage.py bootstrap_system_users
+echo "System bootstrap complete!"
+
 # Run as development server (for testing)
 python manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
## Summary

Closes the gap where the 5 WhoamI system accounts (`wit_admin`, `wit_bot`, `jaewon`, `koyrkr`, `njs`) weren't auto-created on DB setup. Before this PR, only the single `admin` superuser was created via `start.sh` env vars; running `seed_wit_admin_chats` on a fresh DB failed because `resolve_operators()` raised `LookupError` for the 3 missing operator emails. `wit_admin` and `wit_bot` were also created (when the seed commands ran manually) as plain users with no password and no superuser flag.

## Changes

- **New management command** `chat/management/commands/bootstrap_system_users.py` — idempotent, creates the 5 missing system accounts as superusers (default password `Adoor2020:)`, override via `SYSTEM_USER_DEFAULT_PASSWORD` env var), then chains the existing `ensure_wit_admin_user`, `ensure_wit_bot_user`, `ensure_blast_rooms`, `ensure_system_connections`, `provision_user_rooms`, and `ensure_wit_bot_room` helpers to provision rooms for every regular user.
- **`start.sh`** — calls `python manage.py bootstrap_system_users` after the existing `DJANGO_SUPERUSER_*` flow, so a fresh Docker spin-up ends up with all 5 accounts present and connected.

## Idempotency / Safety

- Existing rows are left untouched (no `is_superuser` upgrade, no password reset). Only newly-created rows get the superuser flags + default password.
- The default password is throwaway — operators rotate it via shell or admin once provisioned.
- All sub-helpers called are themselves idempotent (`get_or_create` semantics).

## Test plan

- [ ] On a fresh DB, run `start.sh` and verify all 5 accounts exist with `is_superuser=True`.
- [ ] Re-run `python manage.py bootstrap_system_users` and confirm it skips existing rows ("leaving as-is" log lines).
- [ ] Log into Django admin as one of the operators with password `Adoor2020:)`.
- [ ] Verify chat rooms exist: each regular user has 1 `wit_admin` chat + 3 proxy rooms + 1 `wit_bot` chat.
- [ ] Run `python manage.py check` and `python manage.py makemigrations --check` — both clean.