### PR TITLE
fix(missions): set May 1, 2026 mission to community-greeting prompt

### DIFF
--- a/adoorback/adoorback/migrations/0003_may_1_mission_hotfix.py
+++ b/adoorback/adoorback/migrations/0003_may_1_mission_hotfix.py
@@ -1,0 +1,62 @@
+"""Hot-fix: set May 1, 2026 Mission of the Day to a community-greeting prompt.
+
+The frontend selects today's mission via `missions[getDayOfYear() % missions.length]`
+(see `WhoamI-Today-frontend/src/components/share/MissionOfTheDay.tsx:13` and
+`src/routes/discover/Discover.tsx:114`). For May 1, 2026 the day-of-year is 121,
+so we update the row at index `121 % count` (ordered by id) — currently the row
+seeded as 'Ask the community a question'.
+
+Reverse restores the original seed values, so `migrate adoorback 0002`
+cleanly rolls back this hotfix.
+"""
+from django.db import migrations
+
+
+MAY_1_2026_DAY_OF_YEAR = 121
+
+NEW_PROMPT = (
+    'Say hi to the WIT user community! Share a public post with something '
+    'that represents you—a drawing, a favorite item, your pet, etc.'
+)
+NEW_TYPE = 'text'
+
+ORIGINAL_PROMPT = 'Ask the community a question'
+ORIGINAL_TYPE = 'question'
+
+
+def _target(Mission):
+    missions = list(Mission.objects.order_by('id'))
+    if not missions:
+        return None
+    return missions[MAY_1_2026_DAY_OF_YEAR % len(missions)]
+
+
+def set_may_1_mission(apps, schema_editor):
+    Mission = apps.get_model('adoorback', 'Mission')
+    target = _target(Mission)
+    if target is None:
+        return
+    target.prompt = NEW_PROMPT
+    target.type = NEW_TYPE
+    target.save(update_fields=['prompt', 'type'])
+
+
+def restore_may_1_mission(apps, schema_editor):
+    Mission = apps.get_model('adoorback', 'Mission')
+    target = _target(Mission)
+    if target is None:
+        return
+    target.prompt = ORIGINAL_PROMPT
+    target.type = ORIGINAL_TYPE
+    target.save(update_fields=['prompt', 'type'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('adoorback', '0002_seed_missions'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_may_1_mission, restore_may_1_mission),
+    ]


### PR DESCRIPTION
## Summary

Hot-fix to override today's (May 1, 2026) Mission of the Day with a community-greeting prompt. **Do not merge until ready to deploy** — once merged + deployed, today's mission flips immediately for everyone.

## What changes

Data migration `adoorback/0003_may_1_mission_hotfix` that updates the Mission row at index `121 % count` (May 1, 2026 day-of-year, ordered by id):

| Field | Before | After |
|---|---|---|
| `prompt` | "Ask the community a question" | "Say hi to the WIT user community! Share a public post with something that represents you—a drawing, a favorite item, your pet, etc." |
| `type` | `question` | `text` |

## Why this approach

The frontend selects today's mission via `missions[getDayOfYear() % missions.length]` ([`MissionOfTheDay.tsx:13`](https://github.com/ssm0318/WhoamI-Today-frontend/blob/release/final-research/src/components/share/MissionOfTheDay.tsx#L13), [`Discover.tsx:114`](https://github.com/ssm0318/WhoamI-Today-frontend/blob/release/final-research/src/routes/discover/Discover.tsx#L114)). With 30 missions, `121 % 30 = 1`, which corresponds to mission id=2 (the "Ask the community a question" seed row). Updating that row in place is the cleanest way to override today's prompt without touching the rotation logic.

The `type` change from `question` to `text` is necessary so the "Do it" button routes to `/notes/new` (regular post flow) instead of `/questions`.

## Side effect to be aware of

Because this is a permanent DB update keyed off day-of-year, the same prompt will appear again on May 1, 2027. The reverse function restores the original seed values, so `python manage.py migrate adoorback 0002` cleanly rolls this back if needed.

## Test plan

- [x] Migration applied locally via `python manage.py migrate` — clean.
- [x] DB shell verifies row id=2 has the new prompt and type=text.
- [x] `python manage.py check` — clean.
- [x] `python manage.py makemigrations --check` — no pending changes.
- [ ] After deploy, hard-refresh the Discover feed and confirm Mission of the Day card shows the new prompt.
- [ ] Tap "Do it" — should route to `/notes/new` (not `/questions`).