### PR TITLE
fix(chat): exclude user-triggered member_added from their unread count

### DIFF
--- a/adoorback/chat/tests_wit_bot_escalation.py
+++ b/adoorback/chat/tests_wit_bot_escalation.py
@@ -154,6 +154,24 @@ class WitBotEscalationTests(TestCase):
         ).count()
         self.assertEqual(before, after)
 
+    def test_escalation_does_not_inflate_user_unread_count(self):
+        """The 'wit_admin was added' system event the user just triggered
+        should not show up as unread FOR that user — they caused it."""
+        from chat.wit_bot import escalate_to_human
+        # Start clean: simulate alice having read everything in the room
+        # (mark-read endpoint behavior).
+        Message.objects.filter(
+            chat_room=self.alice_room, receiver=self.alice,
+        ).update(is_read=True)
+        self.assertEqual(self.alice.unread_message_cnt, 0)
+        escalate_to_human(self.alice)
+        self.assertEqual(
+            self.alice.unread_message_cnt, 0,
+            "escalation should not inflate alice's unread count: the "
+            "member_added system event must be marked read for the user "
+            "who triggered it.",
+        )
+
     def test_user_leave_evicts_admin_and_demotes_room(self):
         """When the original user 'leaves' their wit_bot escalated room, the
         system reroutes that intent to 'evict admin' — the user stays, the

--- a/adoorback/chat/wit_bot.py
+++ b/adoorback/chat/wit_bot.py
@@ -161,6 +161,13 @@ def escalate_to_human(user):
         event_type='member_added',
     )
     added_msg.event_target_users.set([admin])
+    # The original user triggered the escalation, so the "wit_admin was added"
+    # event isn't an unread message FOR them. Advance their cursor past it.
+    # Admin/bot keep their pre-event cursors so admin's chat list still shows
+    # the room as unread until they actually open it.
+    GroupReadCursor.objects.filter(user=user, chat_room=room).update(
+        last_read_message=added_msg,
+    )
     _broadcast_system_message(room, added_msg)
 
     noti = Notification.objects.create(


### PR DESCRIPTION
## Summary
When a user clicked **Call in the admin** in the wit_bot beta loop, their chat-tab unread count ticked up by 1 even though no real new message arrived for them.

**Root cause:** \`escalate_to_human\` creates a \`member_added\` system event with \`sender=wit_bot\` while the room is now \`is_group=True\`. Group unread is computed as messages-after-cursor excluding the user's own sends; the bot-sent system event matches that filter, so it counts as one phantom unread for the user who just triggered the escalation.

**Fix:** After creating the \`member_added\` message, advance only the original user's \`GroupReadCursor\` past it. Admin and bot keep their pre-event cursors so admin's chat list still shows the room as unread until they actually open it.

## Test plan
- [x] New test \`test_escalation_does_not_inflate_user_unread_count\` asserts unread stays at 0 across escalation
- [x] All 11 escalation tests pass; full \`chat\` suite 115/115 passes