### PR TITLE
feat(chat): wit_bot dismiss-admin endpoint + auto-nav after escalation

### DIFF
--- a/adoorback/chat/serializers.py
+++ b/adoorback/chat/serializers.py
@@ -25,7 +25,7 @@ class MessageSerializer(serializers.ModelSerializer):
     class Meta:
         model = Message
         fields = [
-            'id', 'sender', 'emoji', 'content', 'image', 'is_read', 'created_at',
+            'id', 'chat_room_id', 'sender', 'emoji', 'content', 'image', 'is_read', 'created_at',
             'parent', 'reactions', 'parent_preview',
             'shared_content_type', 'shared_object_id', 'shared_content_preview',
             'event_type', 'event_target_users', 'bot_payload',

--- a/adoorback/chat/tests_wit_bot_escalation.py
+++ b/adoorback/chat/tests_wit_bot_escalation.py
@@ -172,45 +172,59 @@ class WitBotEscalationTests(TestCase):
             "who triggered it.",
         )
 
-    def test_user_leave_evicts_admin_and_demotes_room(self):
-        """When the original user 'leaves' their wit_bot escalated room, the
-        system reroutes that intent to 'evict admin' — the user stays, the
-        admin is removed, and the room demotes to a 1-on-1 with the bot."""
+    def test_dismiss_admin_endpoint_demotes_room_for_original_user(self):
+        """POST /chat/groups/{id}/dismiss-admin/ run by the original user
+        evicts admin/operators and demotes the room back to a 1-on-1 with
+        the bot. Leave (POST /leave/) keeps its standard meaning of removing
+        the requester from members."""
         from chat.wit_bot import escalate_to_human
         escalate_to_human(self.alice)
         self.alice_room.refresh_from_db()
         self.assertTrue(self.alice_room.is_group)
 
-        from chat.views import GroupChatLeave
+        from chat.views import GroupChatDismissAdmin
         factory = APIRequestFactory()
-        req = factory.post(f'/api/chat/groups/{self.alice_room.id}/leave/')
+        req = factory.post(f'/api/chat/groups/{self.alice_room.id}/dismiss-admin/')
         force_authenticate(req, user=self.alice)
-        resp = GroupChatLeave.as_view()(req, pk=self.alice_room.id)
+        resp = GroupChatDismissAdmin.as_view()(req, pk=self.alice_room.id)
         self.assertEqual(resp.status_code, 200)
-        self.assertEqual(resp.data['status'], 'admin_evicted')
+        self.assertEqual(resp.data['status'], 'admin_dismissed')
         self.assertEqual(resp.data['redirect_user_id'], self.bot.id)
 
         self.alice_room.refresh_from_db()
         self.assertFalse(self.alice_room.is_group)
         self.assertEqual(self.alice_room.name, '')
         self.assertEqual(self.alice_room.members.count(), 0)
-        # user1/user2 unchanged so the 1-on-1 lookup still finds the room.
         self.assertEqual(
             {self.alice_room.user1_id, self.alice_room.user2_id},
             {self.alice.id, self.bot.id},
         )
 
-    def test_engine_resumes_after_user_evicts_admin(self):
-        """After admin eviction the room is back to a 1-on-1, so the wit_bot
+    def test_dismiss_admin_endpoint_rejected_for_non_owner(self):
+        """A user who isn't the original owner of the wit_bot thread (e.g.
+        the admin themselves, or a different user) can't call the dismiss
+        endpoint."""
+        from chat.wit_bot import escalate_to_human
+        escalate_to_human(self.alice)
+        from chat.views import GroupChatDismissAdmin
+        factory = APIRequestFactory()
+        # Admin trying to dismiss themselves via this endpoint should be denied.
+        req = factory.post(f'/api/chat/groups/{self.alice_room.id}/dismiss-admin/')
+        force_authenticate(req, user=self.admin)
+        resp = GroupChatDismissAdmin.as_view()(req, pk=self.alice_room.id)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_engine_resumes_after_dismiss_admin(self):
+        """After dismiss-admin the room is back to a 1-on-1, so the wit_bot
         engine signal fires again on the user's next message."""
         from chat.wit_bot import escalate_to_human
         escalate_to_human(self.alice)
 
-        from chat.views import GroupChatLeave
+        from chat.views import GroupChatDismissAdmin
         factory = APIRequestFactory()
-        req = factory.post(f'/api/chat/groups/{self.alice_room.id}/leave/')
+        req = factory.post(f'/api/chat/groups/{self.alice_room.id}/dismiss-admin/')
         force_authenticate(req, user=self.alice)
-        GroupChatLeave.as_view()(req, pk=self.alice_room.id)
+        GroupChatDismissAdmin.as_view()(req, pk=self.alice_room.id)
         self.alice_room.refresh_from_db()
 
         before = Message.objects.filter(
@@ -224,6 +238,30 @@ class WitBotEscalationTests(TestCase):
             chat_room=self.alice_room, sender=self.bot,
         ).count()
         self.assertGreater(after, before)
+
+    def test_user_leave_actually_removes_user_from_escalated_room(self):
+        """Leave is for leaving the chatroom yourself. In a wit_bot escalated
+        room, that means the user is removed from members (NOT a reroute to
+        admin eviction). The room stays is_group=True with [bot, admin]."""
+        from chat.wit_bot import escalate_to_human
+        escalate_to_human(self.alice)
+        self.alice_room.refresh_from_db()
+        self.assertTrue(self.alice_room.is_group)
+
+        from chat.views import GroupChatLeave
+        factory = APIRequestFactory()
+        req = factory.post(f'/api/chat/groups/{self.alice_room.id}/leave/')
+        force_authenticate(req, user=self.alice)
+        resp = GroupChatLeave.as_view()(req, pk=self.alice_room.id)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data['status'], 'left')
+
+        self.alice_room.refresh_from_db()
+        self.assertTrue(self.alice_room.is_group)
+        self.assertEqual(
+            set(self.alice_room.members.values_list('id', flat=True)),
+            {self.bot.id, self.admin.id},
+        )
 
     def test_admin_button_tap_triggers_escalation(self):
         """The new beta-loop entry point: tapping 'Call in the admin' button

--- a/adoorback/chat/urls.py
+++ b/adoorback/chat/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     path('groups/', views.GroupChatCreate.as_view(), name='group-chat-create'),
     path('groups/<int:pk>/', views.GroupChatUpdate.as_view(), name='group-chat-update'),
     path('groups/<int:pk>/leave/', views.GroupChatLeave.as_view(), name='group-chat-leave'),
+    path('groups/<int:pk>/dismiss-admin/', views.GroupChatDismissAdmin.as_view(), name='group-chat-dismiss-admin'),
     path('groups/<int:pk>/messages/', views.GroupMessageList.as_view(), name='group-message-list'),
     path('groups/<int:pk>/mark-read/', views.MarkGroupMessagesRead.as_view(), name='mark-group-messages-read'),
     # Chat requests

--- a/adoorback/chat/views.py
+++ b/adoorback/chat/views.py
@@ -931,14 +931,6 @@ class GroupChatLeave(generics.GenericAPIView):
         if not room.members.filter(id=user.id).exists():
             raise exceptions.PermissionDenied("You are not a member of this group.")
 
-        # Special case: when the original user "leaves" their own escalated
-        # wit_bot support thread, what they actually want is to dismiss the
-        # admin and go back to a 1-on-1 with the bot. Detect that and reroute
-        # so the user stays in the room and the bot engine resumes replying.
-        bot, evictees = _wit_bot_escalation_evictees(room, user)
-        if bot is not None:
-            return self._evict_admins_and_demote(room, user, bot, evictees)
-
         leave_msg = Message.objects.create(
             chat_room=room, sender=user, receiver=None,
             event_type='member_left',
@@ -958,10 +950,30 @@ class GroupChatLeave(generics.GenericAPIView):
         room.delete()
         return Response({'status': 'left'})
 
-    def _evict_admins_and_demote(self, room, user, bot, evictees):
-        """Remove non-(user, bot) members from a wit_bot escalated room and
-        demote it back to a 1-on-1 with the bot. Restores the shape that
-        ensure_wit_bot_room creates so the engine signal fires again."""
+
+class GroupChatDismissAdmin(generics.GenericAPIView):
+    """POST /chat/groups/{id}/dismiss-admin/ — for the user who triggered a
+    wit_bot escalation, dismiss wit_admin (and any other operators) and demote
+    the room back to a 1-on-1 with the bot. Only the original user (the non-bot
+    user1/user2 of the room) may call this."""
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def post(self, request, pk):
+        user = request.user
+        try:
+            room = ChatRoom.objects.get(id=pk, is_group=True)
+        except ChatRoom.DoesNotExist:
+            raise exceptions.NotFound("Group not found.")
+
+        bot, evictees = _wit_bot_escalation_evictees(room, user)
+        if bot is None:
+            raise exceptions.PermissionDenied(
+                "This action is only available in your own wit_bot support thread."
+            )
+
         if evictees:
             evict_msg = Message.objects.create(
                 chat_room=room, sender=user, receiver=None,
@@ -983,7 +995,7 @@ class GroupChatLeave(generics.GenericAPIView):
         GroupReadCursor.objects.filter(chat_room=room).delete()
 
         return Response({
-            'status': 'admin_evicted',
+            'status': 'admin_dismissed',
             'redirect_user_id': bot.id,
         })
 


### PR DESCRIPTION
## Summary
Three coupled changes for the wit_bot escalation flow:

- **Restore `POST /chat/groups/<id>/leave/` to its original semantics.** The earlier attempt rerouted user-leaves of escalated wit_bot rooms into admin eviction; that conflated two distinct intents (\"I want to leave\" vs \"I want the admin gone\"). Leave now actually removes the requester from members again.
- **New endpoint: `POST /chat/groups/<id>/dismiss-admin/`.** Only callable by the original user of a wit_bot escalated room. Evicts non-(user, bot) members, demotes \`is_group=False\`, clears members, name, and group read cursors. Returns \`{status: 'admin_dismissed', redirect_user_id: <bot_id>}\`.
- **Expose `chat_room_id` on `MessageSerializer`.** The frontend uses this to navigate the user to \`/chats/group/<id>\` immediately after the \"Call in the admin\" button tap, so wit_admin's \"was added\" event and the bot's acknowledgement appear without a manual refresh.

## Test plan
- [x] \`python manage.py test chat\` — all chat tests pass
- [x] \`python manage.py test chat.tests_wit_bot_escalation\` — 13/13 pass:
  - Dismiss endpoint demotes room for original user
  - Dismiss endpoint returns 403 for non-owner (admin)
  - Engine resumes after dismiss-admin
  - Leave still actually removes the requester from members in an escalated room

Paired with frontend PR.