### PR TITLE
fix(surveys): capitalize Quick Mock Survey title

### DIFF
--- a/adoorback/surveys/fixtures/mock_test_today.yaml
+++ b/adoorback/surveys/fixtures/mock_test_today.yaml
@@ -8,7 +8,7 @@
 
 - slug: mock_test_2026q2
   title:
-    en: "quick mock survey"
+    en: "Quick Mock Survey"
     ko: "간단 모의 설문"
   description:
     en: "short survey"


### PR DESCRIPTION
## Summary
- Capitalize the title of `mock_test_2026q2` from "quick mock survey" → "Quick Mock Survey" in the fixture.
- Title fix only takes effect on a host once `python manage.py load_surveys adoorback/surveys/fixtures/mock_test_today.yaml` is re-run after deploy (load_surveys is upsert by slug).

## Notes for prod deploy
On the remote host, after this merges and deploys:
\`\`\`bash
docker compose exec web python manage.py load_surveys adoorback/surveys/fixtures/mock_test_today.yaml
docker compose exec web python manage.py shell -c "
from datetime import date
from surveys.models import Survey, ScheduledSurvey, CADENCE_DAILY
ScheduledSurvey.objects.update_or_create(
    cadence=CADENCE_DAILY, sequence_index=900,
    defaults={
        'survey': Survey.objects.get(slug='mock_test_2026q2'),
        'window_start': date(2026, 5, 1),
        'window_end': date(2026, 5, 1),
        'allow_late': False,
    },
)
"
\`\`\`
First command updates the Survey row's title (and creates it if missing). Second command creates the May-1 daily slot so SurveyOfTheDay actually renders.

## Test plan
- [x] Local DB updated via load_surveys; /share renders "Quick Mock Survey"
- [x] No code/migration changes — fixture-only