### PR TITLE
Ver.Q 노트/답변 좋아요 목록 및 Q 시리얼라이저

### DIFF
--- a/adoorback/check_in/serializers.py
+++ b/adoorback/check_in/serializers.py
@@ -345,7 +345,9 @@ class CheckInPostSerializer(serializers.ModelSerializer):
 
     def get_like_count(self, obj):
         request = self.context.get('request')
-        if request is None or obj.author != request.user:
+        if request is None or not request.user.is_authenticated:
+            return None
+        if not obj.is_audience(request.user):
             return None
         blocked_user_ids = request.user.user_report_blocked_ids
         return obj.check_in_post_likes.exclude(user_id__in=blocked_user_ids).count()
@@ -409,7 +411,9 @@ class CheckInPostFriendStorySerializer(serializers.ModelSerializer):
 
     def get_like_count(self, obj):
         request = self.context.get('request')
-        if request is None or obj.author != request.user:
+        if request is None or not request.user.is_authenticated:
+            return None
+        if not obj.is_audience(request.user):
             return None
         blocked_ids = request.user.user_report_blocked_ids
         return obj.check_in_post_likes.exclude(user_id__in=blocked_ids).count()

--- a/adoorback/check_in/views.py
+++ b/adoorback/check_in/views.py
@@ -1104,7 +1104,7 @@ class CheckInPostComments(generics.ListAPIView):
 class CheckInPostLikes(generics.ListAPIView):
     """GET /api/check_in/posts/<pk>/likes/
 
-    List users who liked a CheckInPost. Only the post author can view this.
+    List users who liked a CheckInPost (any user in the post audience).
     """
     permission_classes = [IsAuthenticated]
 
@@ -1118,8 +1118,8 @@ class CheckInPostLikes(generics.ListAPIView):
     def get_queryset(self):
         current_user = self.request.user
         post = get_object_or_404(CheckInPost, id=self.kwargs.get('pk'))
-        if post.author != current_user:
-            raise exceptions.PermissionDenied("Only the author can view likes.")
+        if not post.is_audience(current_user):
+            raise exceptions.PermissionDenied("You cannot view likes on this post.")
         blocked_ids = current_user.user_report_blocked_ids
         return post.check_in_post_likes.exclude(
             user_id__in=blocked_ids,

--- a/adoorback/note/serializers_q.py
+++ b/adoorback/note/serializers_q.py
@@ -24,11 +24,18 @@ class QNoteSerializer(BaseNoteSerializer):
         return list(value)
 
     def get_like_count(self, obj):
-        return obj.liked_user_ids.count()
+        request = self.context.get('request')
+        qs = obj.note_likes.all()
+        if request is not None and request.user.is_authenticated:
+            qs = qs.exclude(user_id__in=request.user.user_report_blocked_ids)
+        return qs.count()
 
     def get_like_user_sample(self, obj):
-        recent_likes = obj.note_likes.order_by('-created_at')[:3]
-        recent_users = [like.user for like in recent_likes]
+        request = self.context.get('request')
+        qs = obj.note_likes.order_by('-created_at')
+        if request is not None and request.user.is_authenticated:
+            qs = qs.exclude(user_id__in=request.user.user_report_blocked_ids)
+        recent_users = [like.user for like in qs[:3]]
         return UserMinimalSerializer(recent_users, many=True, context=self.context).data
 
     class Meta(BaseNoteSerializer.Meta):

--- a/adoorback/note/urls.py
+++ b/adoorback/note/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('<int:pk>/', views.NoteDetail.as_view(), name='note-detail'),
     path('<int:pk>/comments/', views.NoteComments.as_view(), name='note-comments'),
     path('<int:pk>/interactions/', views.NoteInteractions.as_view(), name='note-interaction-user-list'),
+    path('<int:pk>/likes/', views.NoteLikes.as_view(), name='note-likes'),
     path('read/', views.NoteRead.as_view(), name='note-read'),
 
     path('notice/', views.NoticeList.as_view(), name='notice-list'),

--- a/adoorback/note/views.py
+++ b/adoorback/note/views.py
@@ -15,7 +15,7 @@ from rest_framework.views import APIView
 from adoorback.utils.permissions import IsNotBlocked, IsAuthorOrReadOnly, IsShared
 from adoorback.utils.validators import adoor_exception_handler
 import comment.serializers as cs
-from like.serializers import InteractionSerializer
+from like.serializers import InteractionSerializer, LikeSerializer
 from adoorback.utils.video import validate_video_file, generate_video_thumbnail
 from note.models import Note, NoteImage, NoteVideo
 from note.serializers import NoteSerializer
@@ -161,6 +161,29 @@ class NoteInteractions(generics.ListAPIView):
         )
 
         return combined_interactions
+
+
+class NoteLikes(generics.ListAPIView):
+    """GET /api/notes/<pk>/likes/ — paginated likes for viewers in the note audience."""
+
+    serializer_class = LikeSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def get_queryset(self):
+        from like.models import Like
+
+        note_id = self.kwargs['pk']
+        note = get_object_or_404(Note, pk=note_id)
+        if not note.is_audience(self.request.user):
+            raise PermissionDenied("You do not have permission to view likes on this note.")
+
+        blocked_ids = self.request.user.user_report_blocked_ids
+        return Like.objects.filter(content_type__model='note', object_id=note_id).exclude(
+            user_id__in=blocked_ids,
+        ).order_by('-created_at')
 
 
 class NoteRead(generics.UpdateAPIView):

--- a/adoorback/qna/serializers_q.py
+++ b/adoorback/qna/serializers_q.py
@@ -39,11 +39,18 @@ class QResponseSerializer(AdoorBaseSerializer):
         return current_user_id in obj.reader_ids
 
     def get_like_count(self, obj):
-        return obj.response_likes.count()
+        request = self.context.get('request')
+        qs = obj.response_likes.all()
+        if request is not None and request.user.is_authenticated:
+            qs = qs.exclude(user_id__in=request.user.user_report_blocked_ids)
+        return qs.count()
 
     def get_like_user_sample(self, obj):
-        recent_likes = obj.response_likes.order_by('-created_at')[:3]
-        recent_users = [like.user for like in recent_likes]
+        request = self.context.get('request')
+        qs = obj.response_likes.order_by('-created_at')
+        if request is not None and request.user.is_authenticated:
+            qs = qs.exclude(user_id__in=request.user.user_report_blocked_ids)
+        recent_users = [like.user for like in qs[:3]]
         return UserMinimalSerializer(recent_users, many=True, context=self.context).data
 
     class Meta(AdoorBaseSerializer.Meta):

--- a/adoorback/qna/urls.py
+++ b/adoorback/qna/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path('responses/<int:pk>/', views.ResponseDetail.as_view(), name='response-detail'),
     path('responses/<int:pk>/comments/', views.ResponseComments.as_view(), name='response-comments'),
     path('responses/<int:pk>/interactions/', views.ResponseInteractions.as_view(), name='response-interaction-user-list'),
+    path('responses/<int:pk>/likes/', views.ResponseLikes.as_view(), name='response-likes'),
     path('responses/read/', views.ResponseRead.as_view(), name='response-read'),
 
     # Question related

--- a/adoorback/qna/views.py
+++ b/adoorback/qna/views.py
@@ -21,7 +21,7 @@ from adoorback.utils.permissions import IsAuthorOrReadOnly, IsShared, IsNotBlock
 from adoorback.utils.validators import adoor_exception_handler
 import comment.serializers as cs
 import qna.serializers as qs
-from like.serializers import InteractionSerializer
+from like.serializers import InteractionSerializer, LikeSerializer
 from qna.models import Response, Question, ResponseRequest
 
 User = get_user_model()
@@ -164,6 +164,29 @@ class ResponseInteractions(generics.ListAPIView):
         )
 
         return combined_interactions
+
+
+class ResponseLikes(generics.ListAPIView):
+    """GET /api/qna/responses/<pk>/likes/ — paginated likes for viewers in the response audience."""
+
+    serializer_class = LikeSerializer
+    permission_classes = [IsAuthenticated]
+
+    def get_exception_handler(self):
+        return adoor_exception_handler
+
+    def get_queryset(self):
+        from like.models import Like
+
+        response_id = self.kwargs['pk']
+        response = get_object_or_404(Response, pk=response_id)
+        if not response.is_audience(self.request.user):
+            raise PermissionDenied("You do not have permission to view likes on this response.")
+
+        blocked_ids = self.request.user.user_report_blocked_ids
+        return Like.objects.filter(content_type__model='response', object_id=response_id).exclude(
+            user_id__in=blocked_ids,
+        ).order_by('-created_at')
 
 
 class ResponseRead(generics.UpdateAPIView):


### PR DESCRIPTION
## 요약
노트·답변에 대한 좋아요 목록 API 및 Q 시리얼라이저 쪽 정리(차단 사용자 제외 등).

## 포함 내용
- 노트/답변 likes 엔드포인트 및 audience 검증
- Q 시리얼라이저 좋아요 집계·차단 필터
- 체크인 연관 조정

프론트 PR(`feature/ver-q-likes-ui-and-api-routing`)과 함께 검증하면 됩니다.

Made with [Cursor](https://cursor.com)