### PR TITLE
feat(alerts): Slack alerts for user reports, content reports, and browse mode survey responses

### DIFF
--- a/adoorback/adoorback/utils/alerts.py
+++ b/adoorback/adoorback/utils/alerts.py
@@ -12,18 +12,7 @@ from user_agents import parse
 from adoorback.filters import get_current_request
 
 
-def send_msg_to_slack(
-    url: Optional[str] = None,
-    text: Optional[str] = None,
-    channel: Optional[str] = None,
-    icon_emoji: Optional[str] = None,
-    username: Optional[str] = None,
-    level: str = "INFO",  # 👈 Default level is INFO
-):
-    allowed_levels = {"WARNING", "ERROR", "CRITICAL"}
-    if level.upper() not in allowed_levels:
-        return  # Don't send unimportant levels
-
+def _build_slack_user_context() -> str:
     request = get_current_request()
     user_info = ""
     if request and hasattr(request, "user") and request.user.is_authenticated:
@@ -56,6 +45,23 @@ def send_msg_to_slack(
         except Exception as e:
             user_info += f"\n📦 Body: [ERROR reading data: {e}]"
 
+    return user_info
+
+
+def send_msg_to_slack(
+    url: Optional[str] = None,
+    text: Optional[str] = None,
+    channel: Optional[str] = None,
+    icon_emoji: Optional[str] = None,
+    username: Optional[str] = None,
+    level: str = "INFO",  # 👈 Default level is INFO
+):
+    allowed_levels = {"WARNING", "ERROR", "CRITICAL"}
+    if level.upper() not in allowed_levels:
+        return  # Don't send unimportant levels
+
+    user_info = _build_slack_user_context()
+
     url = url or os.getenv("SLACK_URL")
     channel = channel or os.getenv("SLACK_CHANNEL")
     username = username or os.getenv("SLACK_USERNAME")
@@ -69,6 +75,42 @@ def send_msg_to_slack(
         "channel": channel,
         "username": username,
         "text": f"[{level.upper()}] {text}{user_info}",
+        "icon_emoji": icon_emoji,
+    }
+
+    try:
+        response = requests.post(url, json=payload, timeout=10)
+        response.raise_for_status()
+    except Exception:
+        traceback.print_exc()
+
+
+def send_user_event_to_slack(
+    text: str,
+    channel: Optional[str] = None,
+    icon_emoji: Optional[str] = None,
+    username: Optional[str] = None,
+):
+    """Send a user-driven event (report, survey response, etc.) to Slack.
+
+    Bypasses the level gate in send_msg_to_slack() because these are info-level
+    by design. Uses a distinct '📨 USER EVENT' header so it's visually
+    separable from error alerts in the same channel.
+    """
+    url = os.getenv("SLACK_URL")
+    channel = channel or os.getenv("SLACK_CHANNEL")
+    username = username or os.getenv("SLACK_USERNAME")
+    icon_emoji = icon_emoji or os.getenv("SLACK_ICON")
+
+    if not url:
+        return
+
+    user_info = _build_slack_user_context()
+
+    payload = {
+        "channel": channel,
+        "username": username,
+        "text": f"📨 *USER EVENT*\n{text}{user_info}",
         "icon_emoji": icon_emoji,
     }
 

--- a/adoorback/browse_mode/views.py
+++ b/adoorback/browse_mode/views.py
@@ -18,6 +18,8 @@ from browse_mode.serializers import (
     BrowseModeWishlistEntrySerializer,
 )
 
+from adoorback.utils.alerts import send_user_event_to_slack
+
 
 class BrowseModePresetList(generics.ListCreateAPIView):
     serializer_class = BrowseModePresetSerializer
@@ -88,4 +90,13 @@ class BrowseModeWishlistCreate(generics.CreateAPIView):
     permission_classes = [IsAuthenticated]
 
     def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+        entry = serializer.save(user=self.request.user)
+        content = entry.content or ''
+        preview = content[:300] + ('…' if len(content) > 300 else '')
+        send_user_event_to_slack(
+            f"*📝 Browse Mode Survey Response*\n"
+            f"```\n"
+            f"User: {self.request.user.username} (ID: {self.request.user.id})\n"
+            f"Content: {preview}\n"
+            f"```"
+        )

--- a/adoorback/content_report/views.py
+++ b/adoorback/content_report/views.py
@@ -6,6 +6,7 @@ from rest_framework.permissions import IsAuthenticated
 from content_report.models import ContentReport
 from content_report.serializers import ContentReportSerializer
 
+from adoorback.utils.alerts import send_user_event_to_slack
 from adoorback.utils.content_types import get_generic_relation_type
 from adoorback.utils.validators import adoor_exception_handler
 
@@ -27,3 +28,10 @@ class ContentReportList(generics.CreateAPIView):
 
         if content_type and object_id:
             serializer.save(user=user, content_type_id=content_type_id, object_id=object_id)
+            send_user_event_to_slack(
+                f"*🚩 Content Report*\n"
+                f"```\n"
+                f"Reporter: {user.username} (ID: {user.id})\n"
+                f"Target: {content_type} #{object_id}\n"
+                f"```"
+            )

--- a/adoorback/user_report/views.py
+++ b/adoorback/user_report/views.py
@@ -1,3 +1,4 @@
+from django.contrib.auth import get_user_model
 from django.db import transaction, IntegrityError
 from rest_framework import generics
 from rest_framework.permissions import IsAuthenticated
@@ -5,7 +6,10 @@ from rest_framework.permissions import IsAuthenticated
 from user_report.models import UserReport
 from user_report.serializers import UserReportSerializer
 
+from adoorback.utils.alerts import send_user_event_to_slack
 from adoorback.utils.validators import adoor_exception_handler
+
+User = get_user_model()
 
 
 class UserReportList(generics.CreateAPIView):
@@ -21,8 +25,19 @@ class UserReportList(generics.CreateAPIView):
 
     @transaction.atomic
     def perform_create(self, serializer):
+        reporter = self.request.user
+        reported_user_id = self.request.data['reported_user_id']
         try:
-            serializer.save(user=self.request.user,
-                            reported_user_id=self.request.data['reported_user_id'])
+            serializer.save(user=reporter, reported_user_id=reported_user_id)
         except IntegrityError:
-            pass
+            return
+
+        reported_user = User.objects.filter(id=reported_user_id).only('username').first()
+        reported_username = reported_user.username if reported_user else '(deleted)'
+        send_user_event_to_slack(
+            f"*🚩 User Report*\n"
+            f"```\n"
+            f"Reporter: {reporter.username} (ID: {reporter.id})\n"
+            f"Target: {reported_username} (ID: {reported_user_id})\n"
+            f"```"
+        )


### PR DESCRIPTION
## Summary
- Add `send_user_event_to_slack` helper that routes info-level user-driven events to the existing `SLACK_CHANNEL`, prefixed with `📨 USER EVENT` so it stays visually separable from error alerts.
- Extract the shared request-context builder (`_build_slack_user_context`) so both error and user-event helpers reuse the same `👤 User / 🔑 Token / 📄 Page / 💻 OS / 📦 Body` block.
- Wire the helper into three creation flows so the team gets a Slack ping for every:
  - 🚩 User Report (`POST /api/user_reports/`)
  - 🚩 Content Report (`POST /api/content_reports/`)
  - 📝 Browse Mode Survey Response (`POST /api/browse_mode/wishlist/`)

## Notes
- No new env var. Reuses `SLACK_URL` / `SLACK_CHANNEL` / `SLACK_USERNAME`.
- `send_msg_to_slack` level gate (WARNING/ERROR/CRITICAL) is unchanged — existing error alert paths are untouched.
- `UserReport` `perform_create` early-returns on `IntegrityError` (duplicate report) so we don't fire a Slack ping for no-op creates. `post_save` signal that cleans up friendships is left alone.
- Wishlist `content` is truncated to 300 chars in the Slack payload (full content stays in DB).
- No model / migration changes.

## Test plan
- [ ] \`python manage.py check\` clean
- [ ] \`python manage.py makemigrations --check\` clean
- [ ] \`POST /api/user_reports/\` → DB row + 🚩 User Report Slack message
- [ ] \`POST /api/content_reports/\` → DB row + 🚩 Content Report Slack message
- [ ] \`POST /api/browse_mode/wishlist/\` → DB row + 📝 Browse Mode Survey Response Slack message (verify >300 char truncation)
- [ ] Existing error alert path still posts as \`[ERROR] …\` (regression check)