### PR TITLE
chore(chat): rename onboarding button to 'Onboarding (coming soon)'

### DIFF
--- a/adoorback/chat/tests_wit_bot_engine.py
+++ b/adoorback/chat/tests_wit_bot_engine.py
@@ -53,7 +53,7 @@ class WitBotBetaLoopTests(TestCase):
         self.assertEqual(latest.bot_payload.get('kind'), 'card')
         labels = [b['label'] for b in latest.bot_payload['buttons']]
         self.assertEqual(labels, [
-            'Get started with onboarding',
+            'Onboarding (coming soon)',
             "I'm confused",
             'tehehe',
             'Call in the admin',
@@ -64,7 +64,7 @@ class WitBotBetaLoopTests(TestCase):
     def test_onboarding_choice_replies_with_pool_text(self):
         from chat.wit_bot_engine import BETA_REPLIES
         before = self._bot_replies().count()
-        self._send_choice('onboarding', 'Get started with onboarding')
+        self._send_choice('onboarding', 'Onboarding (coming soon)')
         latest = self._bot_replies().order_by('-created_at').first()
         self.assertEqual(self._bot_replies().count(), before + 1)
         self.assertIn(latest.content, BETA_REPLIES)
@@ -146,7 +146,7 @@ class WitBotBetaLoopTests(TestCase):
         self.assertEqual(welcome.bot_payload['kind'], 'card')
         labels = [b['label'] for b in welcome.bot_payload['buttons']]
         self.assertEqual(labels, [
-            'Get started with onboarding',
+            'Onboarding (coming soon)',
             "I'm confused",
             'tehehe',
             'Call in the admin',

--- a/adoorback/chat/wit_bot_engine.py
+++ b/adoorback/chat/wit_bot_engine.py
@@ -53,7 +53,7 @@ def _beta_card():
     return {
         "kind": "card",
         "buttons": [
-            {"label": "Get started with onboarding", "action": "reply", "payload": "onboarding"},
+            {"label": "Onboarding (coming soon)", "action": "reply", "payload": "onboarding"},
             {"label": "I'm confused", "action": "reply", "payload": "confused"},
             {"label": "tehehe", "action": "reply", "payload": "tehehe"},
             {"label": "Call in the admin", "action": "reply", "payload": "admin"},


### PR DESCRIPTION
## Summary
The button label \`Get started with onboarding\` read like a functional CTA — tapping it suggested an onboarding flow would start. Today the only behavior is the same \`hehe!\` loop the other joke buttons trigger, so the label can read as a broken flow rather than an intentional placeholder.

Renamed to **\`Onboarding (coming soon)\`** so the label honestly reflects the placeholder state. Payload string (\`'onboarding'\`) is unchanged — no engine logic moves.

## Test plan
- [x] 9/9 \`tests_wit_bot_engine\` tests pass
- [x] 3 hard-coded label assertions updated