### PR TITLE
fix(like): CheckInPost redirect_url 매핑 통일

### DIFF
--- a/adoorback/like/models.py
+++ b/adoorback/like/models.py
@@ -16,6 +16,19 @@ from notification.models import Notification
 
 User = get_user_model()
 
+# Map post-like model `type` to its frontend route segment. Default of
+# `f'{type.lower()}s'` only works when the type is a single lowercase word;
+# `CheckInPost` would otherwise become `/checkinposts/{id}` (no hyphen) and
+# fall through to the frontend's NotFound route.
+_TYPE_URL_SEGMENT = {
+    'CheckInPost': 'check-in-posts',
+}
+
+
+def _post_url(post):
+    segment = _TYPE_URL_SEGMENT.get(post.type, f'{post.type.lower()}s')
+    return f'/{segment}/{post.id}'
+
 
 class LikeManager(SafeDeleteManager):
     use_for_related_fields = True
@@ -81,33 +94,31 @@ def create_like_noti(instance, created, **kwargs):
     content = wrap_content(raw_content)
 
     if origin.type == 'Comment' and origin.target.type == 'Comment':  # if is reply
-        redirect_url = f'/{origin.target.target.type.lower()}s/' \
-                       f'{origin.target.target.id}'
+        redirect_url = _post_url(origin.target.target)
         Notification.objects.create_or_update_notification(user=user, actor=actor,
                                                            origin=origin, target=target, noti_type="like_reply_noti",
                                                            redirect_url=redirect_url,
                                                            content_en=content, content_ko=content)
     elif origin.type == 'Comment':  # if is comment
-        redirect_url = f'/{origin.target.type.lower()}s/' \
-                       f'{origin.target.id}'
+        redirect_url = _post_url(origin.target)
         Notification.objects.create_or_update_notification(user=user, actor=actor,
                                                            origin=origin, target=target, noti_type="like_comment_noti",
                                                            redirect_url=redirect_url,
                                                            content_en=content, content_ko=content)
     elif origin.type == 'Response':
-        redirect_url = f'/{origin.type.lower()}s/{origin.id}'
+        redirect_url = _post_url(origin)
         Notification.objects.create_or_update_notification(user=user, actor=actor,
                                                            origin=origin, target=target, noti_type="like_response_noti",
                                                            redirect_url=redirect_url,
                                                            content_en=content, content_ko=content)
     elif origin.type == 'Note':
-        redirect_url = f'/{origin.type.lower()}s/{origin.id}'
+        redirect_url = _post_url(origin)
         Notification.objects.create_or_update_notification(user=user, actor=actor,
                                                            origin=origin, target=target, noti_type="like_note_noti",
                                                            redirect_url=redirect_url,
                                                            content_en=content, content_ko=content)
     elif origin.type == 'CheckInPost':
-        redirect_url = f'/check-in-posts/{origin.id}'
+        redirect_url = _post_url(origin)
         Notification.objects.create_or_update_notification(user=user, actor=actor,
                                                            origin=origin, target=target, noti_type="like_check_in_post_noti",
                                                            redirect_url=redirect_url,


### PR DESCRIPTION
## Summary

- 좋아요 노티의 `redirect_url` 생성을 `_post_url(post)` 헬퍼로 통일.
- 기존 분기에서 `f'/{type.lower()}s/'` 변환은 단일 단어 type (Note/Response) 에만 동작했고, **CheckInPost 는 별도 분기로만 하이픈 형식**(`/check-in-posts/`)을 만들었음. 그래서 댓글/답글 좋아요 분기를 타면 `/checkinposts/{id}` (하이픈 없음) 가 만들어져 프론트 라우트와 안 맞고 NotFound 로 빠지는 동반 버그가 있었음.
- 모든 분기가 같은 매핑을 쓰게 합쳐서 그 동반 버그도 같이 해결.

## Pair PR

- frontend: GooJinSun/WhoAmI-Today-frontend `fix/check-in-post-detail-route` (`/check-in-posts/:id` 라우트 신규 추가)

## Affected file

- `adoorback/like/models.py` — `_post_url` 헬퍼 + 4개 분기 적용. signal 코드만 변경, 모델/마이그레이션 변경 없음.

## Test plan

- [x] `python manage.py check` clean
- [x] `python manage.py makemigrations --check` clean
- [x] `python manage.py test notification check_in` 65 tests pass
- [ ] (수동) test user A 의 CheckInPost 에 user B 가 좋아요 → A 가 노티 클릭 → `/check-in-posts/{id}` 도착 (frontend PR 머지 후 viewer 표시)
- [ ] (수동) A 가 자기 CheckInPost 에 댓글 → B 가 댓글에 좋아요 → A 가 노티 클릭 → `/check-in-posts/{id}` 로 정확히 가는지 확인 (이전엔 `/checkinposts/{id}` 였음)