### PR TITLE
Remove ping daily limit

### DIFF
--- a/adoorback/check_in/models.py
+++ b/adoorback/check_in/models.py
@@ -451,8 +451,6 @@ class CheckInComponentEntry(AdoorTimestampedModel, SafeDeleteModel):
 
 
 class Poke(AdoorTimestampedModel, SafeDeleteModel):
-    DAILY_POKE_LIMIT = 5
-
     COMPONENT_TYPE_CHOICES = [
         ('song', 'Song'),
         ('mood', 'Mood'),

--- a/adoorback/check_in/views.py
+++ b/adoorback/check_in/views.py
@@ -581,11 +581,7 @@ class PokeCreate(generics.CreateAPIView):
         if sender.current_ver != receiver.current_ver:
             raise exceptions.PermissionDenied("Cannot poke a user on a different version.")
 
-        # Check daily poke limit
         today_start = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        sent_today = Poke.objects.filter(sender=sender, created_at__gte=today_start).count()
-        if sent_today >= Poke.DAILY_POKE_LIMIT:
-            raise exceptions.Throttled(detail="Daily poke limit reached.")
 
         # Check duplicate: same sender->receiver->component_type today
         component_type = serializer.validated_data.get('component_type')


### PR DESCRIPTION
## Summary
- Remove the backend daily send-count throttle for check-in pings
- Keep same sender/receiver/component duplicate prevention for the day

## Verification
- JSON/i18n not applicable for backend
- python -m py_compile adoorback/check_in/models.py adoorback/check_in/views.py

Note: Django test run was not available in the local Python environment because python-dotenv is not installed.