### PR TITLE
feat(surveys): add May 2 + May 3 pre-study mock daily survey copies

### DIFF
--- a/adoorback/surveys/fixtures/mock_test_today.yaml
+++ b/adoorback/surveys/fixtures/mock_test_today.yaml
@@ -1,12 +1,98 @@
-# One-off "survey of the day" content for QA testing.
+# Pre-study mock daily surveys for May 1–3, 2026. Three Survey rows with
+# identical questions but distinct slugs — `SurveyResponse.UniqueConstraint`
+# forces one response per (user, survey), so each day needs its own Survey
+# row to keep result aggregations separate.
+#
 # Loaded + scheduled via:
 #   python manage.py load_surveys adoorback/surveys/fixtures/mock_test_today.yaml
-#   python manage.py seed_survey_mock_data --email <dev-email> --today-slug mock_test_2026q2
+#   # then create one ScheduledSurvey row per day, e.g.:
+#   python manage.py shell -c "
+#   from datetime import date
+#   from surveys.models import Survey, ScheduledSurvey, CADENCE_DAILY
+#   for slug, day, seq in [
+#       ('mock_test_2026q2',    date(2026, 5, 1), 900),
+#       ('mock_test_2026_05_02', date(2026, 5, 2), 901),
+#       ('mock_test_2026_05_03', date(2026, 5, 3), 902),
+#   ]:
+#       ScheduledSurvey.objects.update_or_create(
+#           cadence=CADENCE_DAILY, sequence_index=seq,
+#           defaults={'survey': Survey.objects.get(slug=slug),
+#                     'window_start': day, 'window_end': day,
+#                     'allow_late': True},
+#       )
+#   "
 #
-# The --today-slug flag creates (or re-points) the daily ScheduledSurvey for
-# today to this survey, so it shows up on /share as Survey of the Day.
+# allow_late=True keeps each pre-study mock day visible in the daily archive
+# even if a user misses the day, so QA can still inspect every result page
+# from one place.
 
 - slug: mock_test_2026q2
+  title:
+    en: "Quick Mock Survey"
+    ko: "간단 모의 설문"
+  description:
+    en: "short survey"
+    ko: "짧은 설문"
+  friend_visible: false
+  results_hidden: false
+  questions:
+    - order: 1
+      type: slider
+      prompt:
+        en: "How are you feeling today?"
+        ko: "오늘 기분이 어떤가요?"
+      low_label: { en: "Terrible", ko: "끔찍해요" }
+      high_label: { en: "Couldn't be better", ko: "더할 나위 없이 좋아요" }
+      slider_min_value: 0
+      slider_max_value: 100
+      result_kind: slider_histogram
+    - order: 2
+      type: single_choice
+      prompt:
+        en: "What's the weather like where you are right now?"
+        ko: "지금 있는 곳의 날씨는 어때요?"
+      result_kind: option_counts
+      options:
+        - { order: 1, value: 1, label: { en: "☀️ Sunny", ko: "☀️ 맑음" } }
+        - { order: 2, value: 2, label: { en: "⛅ Partly cloudy", ko: "⛅ 구름 조금" } }
+        - { order: 3, value: 3, label: { en: "☁️ Cloudy", ko: "☁️ 흐림" } }
+        - { order: 4, value: 4, label: { en: "🌧️ Rainy", ko: "🌧️ 비" } }
+        - { order: 5, value: 5, label: { en: "❄️ Snowy / Other", ko: "❄️ 눈 / 기타" } }
+
+- slug: mock_test_2026_05_02
+  title:
+    en: "Quick Mock Survey"
+    ko: "간단 모의 설문"
+  description:
+    en: "short survey"
+    ko: "짧은 설문"
+  friend_visible: false
+  results_hidden: false
+  questions:
+    - order: 1
+      type: slider
+      prompt:
+        en: "How are you feeling today?"
+        ko: "오늘 기분이 어떤가요?"
+      low_label: { en: "Terrible", ko: "끔찍해요" }
+      high_label: { en: "Couldn't be better", ko: "더할 나위 없이 좋아요" }
+      slider_min_value: 0
+      slider_max_value: 100
+      result_kind: slider_histogram
+    - order: 2
+      type: single_choice
+      prompt:
+        en: "What's the weather like where you are right now?"
+        ko: "지금 있는 곳의 날씨는 어때요?"
+      result_kind: option_counts
+      options:
+        - { order: 1, value: 1, label: { en: "☀️ Sunny", ko: "☀️ 맑음" } }
+        - { order: 2, value: 2, label: { en: "⛅ Partly cloudy", ko: "⛅ 구름 조금" } }
+        - { order: 3, value: 3, label: { en: "☁️ Cloudy", ko: "☁️ 흐림" } }
+        - { order: 4, value: 4, label: { en: "🌧️ Rainy", ko: "🌧️ 비" } }
+        - { order: 5, value: 5, label: { en: "❄️ Snowy / Other", ko: "❄️ 눈 / 기타" } }
+
+- slug: mock_test_2026_05_03
   title:
     en: "Quick Mock Survey"
     ko: "간단 모의 설문"


### PR DESCRIPTION
## Summary
Adds `mock_test_2026_05_02` and `mock_test_2026_05_03` Survey rows with identical content to `mock_test_2026q2`. Each day needs its own slug because `SurveyResponse` is unique per (user, survey).

Without separate slugs, a single Survey scheduled on three days would: (1) allow a user to submit only on the first day they land (subsequent days return 409 *Already submitted*), and (2) pool all three days' responses into a single shared results page.

## Notes for prod deploy
Run on the remote host after this merges and deploys:

\`\`\`bash
docker compose exec web python manage.py load_surveys adoorback/surveys/fixtures/mock_test_today.yaml

docker compose exec web python manage.py shell -c "
from datetime import date
from surveys.models import Survey, ScheduledSurvey, CADENCE_DAILY
for slug, day, seq in [
    ('mock_test_2026q2',     date(2026, 5, 1), 900),
    ('mock_test_2026_05_02', date(2026, 5, 2), 901),
    ('mock_test_2026_05_03', date(2026, 5, 3), 902),
]:
    ScheduledSurvey.objects.update_or_create(
        cadence=CADENCE_DAILY, sequence_index=seq,
        defaults={'survey': Survey.objects.get(slug=slug),
                  'window_start': day, 'window_end': day,
                  'allow_late': True},
    )
"
\`\`\`

`allow_late=True` keeps each mock day visible in the daily archive even when a user skips a day — matches the QA-inspection intent. Both commands are idempotent on re-run.

## Test plan
- [x] `python manage.py check` clean
- [x] `load_surveys` locally creates two new Survey rows; `mock_test_2026q2` updated in place
- [x] Three `ScheduledSurvey` rows created at sequence_index 900–902, dates May 1–3, allow_late=True
- [x] `/api/surveys/past/` returns all three mock entries with correct dates
- [x] `/api/surveys/mock_test_2026_05_02/` and `.../mock_test_2026_05_03/` return the expected slider + single-choice questions
- [ ] After deploy: confirm same on remote