### PR TITLE
Fix chat push notification stacking

### DIFF
--- a/adoorback/chat/models.py
+++ b/adoorback/chat/models.py
@@ -304,7 +304,7 @@ def _send_message_notification(receiver_user, sender, instance, redirect_url, gr
             noti_ko = f"{sender.username}님이 메시지를 보냈습니다!"
             noti_en = f"{sender.username} sent you a message!"
 
-    recent_noti = Notification.objects.find_recent_message(receiver_user, sender)
+    recent_noti = Notification.objects.find_recent_message(receiver_user, sender, instance.chat_room)
 
     if recent_noti:
         current_count = 1

--- a/adoorback/notification/models.py
+++ b/adoorback/notification/models.py
@@ -18,7 +18,7 @@ from notification.helpers import find_like_noti, construct_message
 from firebase_admin.messaging import Message
 from firebase_admin._messaging_utils import (
     UnregisteredError, WebpushConfig, WebpushNotification,
-    APNSConfig, APNSPayload, Aps, ApsAlert, AndroidConfig, AndroidNotification,
+    APNSConfig, APNSPayload, Aps, AndroidConfig, AndroidNotification,
 )
 from custom_fcm.models import CustomFCMDevice
 from safedelete.models import SafeDeleteModel
@@ -149,15 +149,18 @@ class NotificationManager(SafeDeleteManager):
                                                message_ko=message_ko, message_en=message_en)
             NotificationActor.objects.create(user=actor, notification=noti)
 
-    def find_recent_message(self, user, actor):
+    def find_recent_message(self, user, actor, chat_room=None):
         cutoff = timezone.now() - timezone.timedelta(minutes=5)
-        return self.filter(
+        qs = self.filter(
             user=user,
             actors__in=[actor],
             target_type__model='message',
             is_read=False,
             notification_updated_at__gte=cutoff
-        ).order_by('-notification_updated_at').first()
+        )
+        if chat_room:
+            qs = qs.filter(target_id__in=chat_room.messages.values('id'))
+        return qs.order_by('-notification_updated_at').first()
 
 
 def default_user():
@@ -235,6 +238,10 @@ def get_notification_tag(instance):
     origin_model = instance.origin_type.model if instance.origin_type else None
 
     if target_model == 'message':
+        target = getattr(instance, 'target', None)
+        chat_room_id = getattr(target, 'chat_room_id', None)
+        if chat_room_id:
+            return f"chat_message_room_{chat_room_id}"
         if instance.origin_id:
             return f"chat_message_{instance.origin_id}"
     elif target_model == 'messagereaction':
@@ -256,58 +263,62 @@ def notify_firebase(instance):
     tag = get_notification_tag(instance)
     print(f"[FCM DEBUG] notify_firebase called: noti_id={instance.id}, user={instance.user_id}, devices={devices.count()}, tag={tag}")
     for device in devices:
-        body = instance.message_ko if device.language == 'ko' else instance.message_en
-        data = {
-            'notification_id': str(instance.id),
-            'message_en': instance.message_en or '',
-            'message_ko': instance.message_ko or '',
-            'url': instance.redirect_url,
-            'tag': tag,
-            'type': 'new',
-            'content-available': '1',  # for ios silent notification
-            'priority': 'high',  # for android
-        }
-        if device.type == 'web':
-            message = Message(
-                data=data,
-                webpush=WebpushConfig(
-                    notification=WebpushNotification(
-                        title='WhoAmI Today',
-                        body=body,
-                        tag=tag,
-                        renotify=True,
-                        icon='/whoami192.png',
-                    ),
-                ),
-            )
-        elif device.type == 'ios':
-            message = Message(
-                data=data,
-                apns=APNSConfig(
-                    payload=APNSPayload(
-                        aps=Aps(
-                            alert=ApsAlert(title='WhoAmI Today', body=body),
-                            sound='default',
-                            content_available=True,
+        try:
+            body = instance.message_ko if device.language == 'ko' else instance.message_en
+            data = {
+                'notification_id': str(instance.id),
+                'message_en': instance.message_en or '',
+                'message_ko': instance.message_ko or '',
+                'url': instance.redirect_url,
+                'tag': tag,
+                'type': 'new',
+                'content-available': '1',  # for ios silent notification
+                'priority': 'high',  # for android
+            }
+            if device.type == 'web':
+                message = Message(
+                    data=data,
+                    webpush=WebpushConfig(
+                        notification=WebpushNotification(
+                            title='WhoAmI Today',
+                            body=body,
+                            tag=tag,
+                            renotify=True,
+                            icon='/whoami192.png',
                         ),
                     ),
-                ),
-            )
-        elif device.type == 'android':
-            message = Message(
-                data=data,
-                android=AndroidConfig(
-                    priority='high',
-                    notification=AndroidNotification(
-                        title='WhoAmI Today',
-                        body=body,
-                        tag=tag,
+                )
+            elif device.type == 'ios':
+                message = Message(
+                    data=data,
+                    apns=APNSConfig(
+                        headers={
+                            'apns-collapse-id': tag,
+                        },
+                        payload=APNSPayload(
+                            aps=Aps(
+                                alert=body,
+                                sound='default',
+                                content_available=True,
+                                thread_id=tag,
+                            ),
+                        ),
                     ),
-                ),
-            )
-        else:
-            message = Message(data=data)
-        try:
+                )
+            elif device.type == 'android':
+                message = Message(
+                    data=data,
+                    android=AndroidConfig(
+                        priority='high',
+                        notification=AndroidNotification(
+                            title='WhoAmI Today',
+                            body=body,
+                            tag=tag,
+                        ),
+                    ),
+                )
+            else:
+                message = Message(data=data)
             response = device.send_message(message)
             print(f"[FCM DEBUG] sent to device {device.id} (type={device.type}): {response}")
         except UnregisteredError:

--- a/adoorback/notification/tests.py
+++ b/adoorback/notification/tests.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
-from firebase_admin._messaging_utils import ApsAlert
+from firebase_admin import messaging
 
 
 def _make_qs(devices):
@@ -34,7 +34,6 @@ def _make_device(device_id, device_type, language='en'):
 
 
 def _make_notification(user, message_en='Hello!', message_ko='안녕!', redirect_url='/home'):
-    from unittest.mock import PropertyMock
     noti = MagicMock()
     noti.id = 1
     noti.user = user
@@ -56,10 +55,29 @@ def _make_notification(user, message_en='Hello!', message_ko='안녕!', redirect
     return noti
 
 
+def _assert_ios_uses_collapse_tag(test_case, sent_message, expected_tag):
+    test_case.assertEqual(sent_message.data['tag'], expected_tag)
+    test_case.assertEqual(sent_message.apns.headers['apns-collapse-id'], expected_tag)
+    test_case.assertEqual(sent_message.apns.payload.aps.thread_id, expected_tag)
+
+
+def _make_message_notification(user, chat_room_id=123):
+    noti = _make_notification(user, message_en='adoor_2 sent you 3 messages!')
+
+    target_type = MagicMock()
+    target_type.model = 'message'
+    noti.target_type = target_type
+
+    target = MagicMock()
+    target.chat_room_id = chat_room_id
+    noti.target = target
+
+    return noti
+
+
 class NotifyFirebaseIosAlertTest(TestCase):
     """
-    Ensures that the iOS APNS message is built with ApsAlert (not a plain dict),
-    which is what caused the ValueError in production.
+    Ensures that the iOS APNS message is built with an encoder-safe alert.
     """
 
     def setUp(self):
@@ -68,8 +86,8 @@ class NotifyFirebaseIosAlertTest(TestCase):
         )
 
     @patch('notification.models.CustomFCMDevice.objects.filter')
-    def test_ios_alert_is_aps_alert_instance(self, mock_filter):
-        """The Aps.alert field must be an ApsAlert, not a dict."""
+    def test_ios_alert_is_encoder_safe_string(self, mock_filter):
+        """The Aps.alert field must pass Firebase Admin's encoder."""
         ios_device = _make_device(device_id=10, device_type='ios', language='en')
         mock_filter.return_value = _make_qs([ios_device])
 
@@ -82,16 +100,10 @@ class NotifyFirebaseIosAlertTest(TestCase):
         ios_device.send_message.assert_called_once()
         sent_message = ios_device.send_message.call_args[0][0]
 
-        # Drill into the built Message object
         aps = sent_message.apns.payload.aps
-        self.assertIsInstance(
-            aps.alert,
-            ApsAlert,
-            f"Expected ApsAlert instance, got {type(aps.alert)}: {aps.alert!r}\n"
-            "This is the bug that caused the ValueError in production."
-        )
-        self.assertEqual(aps.alert.title, 'WhoAmI Today')
-        self.assertEqual(aps.alert.body, 'You got a like!')
+        self.assertEqual(aps.alert, 'You got a like!')
+        messaging._MessagingService.encode_message(sent_message)
+        _assert_ios_uses_collapse_tag(self, sent_message, 'like_note_42')
 
     @patch('notification.models.CustomFCMDevice.objects.filter')
     def test_ios_alert_uses_korean_body_for_ko_device(self, mock_filter):
@@ -106,7 +118,23 @@ class NotifyFirebaseIosAlertTest(TestCase):
 
         sent_message = ios_device.send_message.call_args[0][0]
         aps = sent_message.apns.payload.aps
-        self.assertEqual(aps.alert.body, '좋아요 받았어요!')
+        self.assertEqual(aps.alert, '좋아요 받았어요!')
+        messaging._MessagingService.encode_message(sent_message)
+
+    @patch('notification.models.CustomFCMDevice.objects.filter')
+    def test_ios_chat_message_uses_room_collapse_id(self, mock_filter):
+        """Chat pushes use the room tag so newer room notifications replace older ones."""
+        ios_device = _make_device(device_id=12, device_type='ios', language='en')
+        mock_filter.return_value = _make_qs([ios_device])
+
+        noti = _make_message_notification(self.user, chat_room_id=123)
+
+        from notification.models import notify_firebase
+        notify_firebase(noti)
+
+        sent_message = ios_device.send_message.call_args[0][0]
+        messaging._MessagingService.encode_message(sent_message)
+        _assert_ios_uses_collapse_tag(self, sent_message, 'chat_message_room_123')
 
     @patch('notification.models.CustomFCMDevice.objects.filter')
     def test_android_does_not_raise(self, mock_filter):
@@ -122,6 +150,26 @@ class NotifyFirebaseIosAlertTest(TestCase):
         android_device.send_message.assert_called_once()
         sent_message = android_device.send_message.call_args[0][0]
         self.assertEqual(sent_message.android.notification.title, 'WhoAmI Today')
+
+    @patch('notification.models.send_msg_to_slack')
+    @patch('notification.models.APNSConfig')
+    @patch('notification.models.CustomFCMDevice.objects.filter')
+    def test_ios_payload_error_does_not_block_other_devices(
+        self, mock_filter, mock_apns_config, _mock_slack
+    ):
+        """A payload construction error for one device must not stop the send loop."""
+        ios_device = _make_device(device_id=21, device_type='ios', language='en')
+        android_device = _make_device(device_id=22, device_type='android', language='en')
+        mock_filter.return_value = _make_qs([ios_device, android_device])
+        mock_apns_config.side_effect = ValueError('bad apns payload')
+
+        noti = _make_notification(self.user)
+
+        from notification.models import notify_firebase
+        notify_firebase(noti)
+
+        ios_device.send_message.assert_not_called()
+        android_device.send_message.assert_called_once()
 
     @patch('notification.models.CustomFCMDevice.objects.filter')
     def test_web_does_not_raise(self, mock_filter):


### PR DESCRIPTION
## Summary
- Add iOS APNs collapse/thread identifiers for stable notification tags so updated notifications replace older ones instead of stacking
- Keep existing replacement behavior for grouped notification types such as likes/reactions/response requests, and switch chat message tags to the chat room so message-count updates replace per room
- Use an encoder-safe string APNs alert to avoid the previous `Aps.alert must be a string or an instance of ApsAlert` failure mode
- Scope recent chat notification aggregation to the same chat room
- Keep Firebase message construction inside the per-device error boundary so one malformed platform payload cannot stop the whole send loop
- Add coverage for iOS collapse payloads, Firebase Admin message encoding, and isolating one-device payload construction failures

## Tests
- git diff --check
- python3 -m py_compile adoorback/notification/models.py adoorback/chat/models.py adoorback/notification/tests.py

Note: Django test execution was not run locally because the active Python environment is missing project dependencies such as python-dotenv.