### PR TITLE
Fix friend list check-in visibility

### DIFF
--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -879,11 +879,13 @@ class FriendListSerializer(UserMinimalSerializer, RecentPostsMixin):
         check_in = self.check_in(obj)
         if not check_in:
             return False
-        effective_vis = self._component_visibility(check_in, visibility_field, updated_at_field)
-        if effective_vis == 'only_me':
-            user = self.context.get('request', None).user
-            return user == obj  # Only visible to the owner
-        return True
+        request = self.context.get('request')
+        viewer = request.user if request is not None else None
+        if viewer is None or not viewer.is_authenticated:
+            return False
+        return viewer_sees_check_in_component(
+            check_in, obj, viewer, visibility_field, updated_at_field
+        )
 
     def get_thought(self, obj):
         if not self._is_component_visible(obj, 'thought_visibility', 'thought_updated_at'):

--- a/adoorback/account/tests_recent_posts_union.py
+++ b/adoorback/account/tests_recent_posts_union.py
@@ -16,6 +16,7 @@ from rest_framework.test import APIRequestFactory, APITestCase
 
 from account.models import Connection
 from account.serializers import FriendListSerializer
+from check_in.models import CheckIn, Song
 from note.models import Note
 from qna.models import Question, Response
 
@@ -264,6 +265,42 @@ class FriendsListRecentPostsIntegrationTests(APITestCase):
         data = self._get_friend_data()
         ids = [p['id'] for p in data['recent_posts']]
         self.assertNotIn(note.id, ids)
+
+    def test_check_in_component_visibility_matches_profile_endpoint(self):
+        """Friend list must not expose components hidden on the profile endpoint."""
+        CheckIn.objects.create(
+            user=self.friend,
+            is_active=True,
+            visibility=['friends'],
+            social_battery='fully_charged',
+            battery_visibility='close_friends',
+            mood=['🙂'],
+            mood_visibility='close_friends',
+            thought='visible to regular friends',
+            thought_visibility='friends',
+            song_visibility='close_friends',
+        )
+        Song.objects.create(
+            user=self.friend,
+            track_id='spotify:track:hidden',
+            is_active=True,
+        )
+
+        list_data = self._get_friend_data()
+        profile_response = self.client.get(f'/api/user/{self.friend.username}/profile/')
+
+        self.assertEqual(profile_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(list_data['social_battery'], None)
+        self.assertEqual(profile_response.data['check_in']['social_battery'], None)
+        self.assertEqual(list_data['mood'], None)
+        self.assertEqual(profile_response.data['check_in']['mood'], [])
+        self.assertEqual(list_data['thought'], 'visible to regular friends')
+        self.assertEqual(
+            profile_response.data['check_in']['thought'],
+            'visible to regular friends',
+        )
+        self.assertEqual(list_data['track_id'], None)
+        self.assertEqual(profile_response.data['check_in']['track_id'], '')
 
     def test_union_of_recent_and_unread(self):
         """Both a recent-read note and an old-unread note should appear."""


### PR DESCRIPTION
## Summary
- apply the same per-component check-in visibility rules to the friends list as profile responses
- prevent regular friends from seeing close-friends-only battery, mood, and song fields in friend list items
- add regression coverage comparing friends list output with the profile endpoint

## Tests
- python -m py_compile account/serializers.py account/tests_recent_posts_union.py
- python manage.py test account.tests_recent_posts_union *(blocked locally: ModuleNotFoundError: No module named 'dotenv')