### PR TITLE
Fix friend feed check-in update source

### DIFF
--- a/adoorback/account/serializers.py
+++ b/adoorback/account/serializers.py
@@ -864,13 +864,20 @@ class FriendListSerializer(UserMinimalSerializer, RecentPostsMixin):
             return None
         return self.context.get('visible_check_in_by_user_id', {}).get(obj.id)
 
+    def _live_check_in_entry(self, obj, component):
+        return self.context.get('live_check_in_entries_by_user_id', {}).get(obj.id, {}).get(component)
+
     def get_check_in_id(self, obj):
         check_in = self.check_in(obj)
         return check_in.id if check_in else None
 
     def get_track_id(self, obj):
-        if not self._is_component_visible(obj, 'song_visibility', 'song_updated_at'):
+        entry = self._live_check_in_entry(obj, 'song')
+        if not entry or not self._is_component_visible(obj, 'song_visibility', 'song_updated_at'):
             return None
+        entry_track_id = (entry.data or {}).get('track_id')
+        if entry_track_id:
+            return entry_track_id
         song = self.context.get('active_song_by_user_id', {}).get(obj.id)
         return song.track_id if song else None
 
@@ -888,22 +895,22 @@ class FriendListSerializer(UserMinimalSerializer, RecentPostsMixin):
         )
 
     def get_thought(self, obj):
-        if not self._is_component_visible(obj, 'thought_visibility', 'thought_updated_at'):
+        entry = self._live_check_in_entry(obj, 'thought')
+        if not entry or not self._is_component_visible(obj, 'thought_visibility', 'thought_updated_at'):
             return None
-        check_in = self.check_in(obj)
-        return check_in.thought if check_in else None
+        return (entry.data or {}).get('thought')
 
     def get_social_battery(self, obj):
-        if not self._is_component_visible(obj, 'battery_visibility', 'battery_updated_at'):
+        entry = self._live_check_in_entry(obj, 'battery')
+        if not entry or not self._is_component_visible(obj, 'battery_visibility', 'battery_updated_at'):
             return None
-        check_in = self.check_in(obj)
-        return check_in.social_battery if check_in else None
+        return (entry.data or {}).get('social_battery')
 
     def get_mood(self, obj):
-        if not self._is_component_visible(obj, 'mood_visibility', 'mood_updated_at'):
+        entry = self._live_check_in_entry(obj, 'mood')
+        if not entry or not self._is_component_visible(obj, 'mood_visibility', 'mood_updated_at'):
             return None
-        check_in = self.check_in(obj)
-        return check_in.mood if check_in else None
+        return (entry.data or {}).get('mood')
 
     def _component_visibility(self, check_in, visibility_field, updated_at_field):
         """Return component visibility."""
@@ -924,18 +931,30 @@ class FriendListSerializer(UserMinimalSerializer, RecentPostsMixin):
         return self._component_visibility(self.check_in(obj), 'thought_visibility', 'thought_updated_at')
 
     def get_battery_updated_at(self, obj):
+        entry = self._live_check_in_entry(obj, 'battery')
+        if entry:
+            return entry.updated_at.isoformat()
         ci = self.check_in(obj)
         return ci.battery_updated_at.isoformat() if ci and ci.battery_updated_at else None
 
     def get_mood_updated_at(self, obj):
+        entry = self._live_check_in_entry(obj, 'mood')
+        if entry:
+            return entry.updated_at.isoformat()
         ci = self.check_in(obj)
         return ci.mood_updated_at.isoformat() if ci and ci.mood_updated_at else None
 
     def get_song_updated_at(self, obj):
+        entry = self._live_check_in_entry(obj, 'song')
+        if entry:
+            return entry.updated_at.isoformat()
         ci = self.check_in(obj)
         return ci.song_updated_at.isoformat() if ci and ci.song_updated_at else None
 
     def get_thought_updated_at(self, obj):
+        entry = self._live_check_in_entry(obj, 'thought')
+        if entry:
+            return entry.updated_at.isoformat()
         ci = self.check_in(obj)
         return ci.thought_updated_at.isoformat() if ci and ci.thought_updated_at else None
 
@@ -953,19 +972,26 @@ class FriendListSerializer(UserMinimalSerializer, RecentPostsMixin):
         if not check_in:
             return []
         out = []
-        if self._is_component_visible(obj, 'battery_visibility', 'battery_updated_at'):
-            if (getattr(check_in, 'social_battery', None) or '').strip():
+        battery_entry = self._live_check_in_entry(obj, 'battery')
+        if battery_entry and self._is_component_visible(obj, 'battery_visibility', 'battery_updated_at'):
+            if ((battery_entry.data or {}).get('social_battery') or '').strip():
                 out.append('battery')
-        if self._is_component_visible(obj, 'mood_visibility', 'mood_updated_at'):
-            mood = getattr(check_in, 'mood', None) or []
+        mood_entry = self._live_check_in_entry(obj, 'mood')
+        if mood_entry and self._is_component_visible(obj, 'mood_visibility', 'mood_updated_at'):
+            mood = (mood_entry.data or {}).get('mood') or []
             if any((m or '').strip() for m in mood):
                 out.append('mood')
-        if self._is_component_visible(obj, 'thought_visibility', 'thought_updated_at'):
-            if (getattr(check_in, 'thought', None) or '').strip():
+        thought_entry = self._live_check_in_entry(obj, 'thought')
+        if thought_entry and self._is_component_visible(obj, 'thought_visibility', 'thought_updated_at'):
+            if ((thought_entry.data or {}).get('thought') or '').strip():
                 out.append('thought')
-        if self._is_component_visible(obj, 'song_visibility', 'song_updated_at'):
-            song = self.context.get('active_song_by_user_id', {}).get(obj.id)
-            if song and (getattr(song, 'track_id', None) or '').strip():
+        song_entry = self._live_check_in_entry(obj, 'song')
+        if song_entry and self._is_component_visible(obj, 'song_visibility', 'song_updated_at'):
+            track_id = (song_entry.data or {}).get('track_id')
+            if not track_id:
+                song = self.context.get('active_song_by_user_id', {}).get(obj.id)
+                track_id = getattr(song, 'track_id', None) if song else None
+            if (track_id or '').strip():
                 out.append('song')
         return out
 

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -1668,6 +1668,68 @@ class FriendList(generics.ListAPIView):
                 friend for friend in friends if not User.user_read(user, friend)
             ]
             self._qs = sorted(friends_with_updates, key=lambda x: x.most_recent_update(user), reverse=True)
+        elif query_type == 'check_in_updates':
+            from check_in.models import CheckInComponentEntry
+
+            friends = friends.exclude(id__in=user.hidden.all())
+            friend_ids = list(friends.values_list('id', flat=True))
+            latest_entry_updated_at_by_friend_id = {}
+            live_entries_by_friend_id = {}
+            live_entries = (
+                CheckInComponentEntry.objects
+                .filter(owner_id__in=friend_ids, superseded_at__isnull=True)
+                .only('owner_id', 'component', 'data', 'updated_at')
+            )
+            for entry in live_entries:
+                live_entries_by_friend_id.setdefault(entry.owner_id, []).append(entry)
+
+            component_visibility_fields = {
+                'battery': ('battery_visibility', 'battery_updated_at'),
+                'mood': ('mood_visibility', 'mood_updated_at'),
+                'song': ('song_visibility', 'song_updated_at'),
+                'thought': ('thought_visibility', 'thought_updated_at'),
+            }
+
+            def entry_has_content(entry):
+                data = entry.data or {}
+                if entry.component == 'battery':
+                    return bool((data.get('social_battery') or '').strip())
+                if entry.component == 'mood':
+                    return any((m or '').strip() for m in data.get('mood') or [])
+                if entry.component == 'thought':
+                    return bool((data.get('thought') or '').strip())
+                if entry.component == 'song':
+                    return bool((data.get('track_id') or '').strip())
+                return False
+
+            for friend in friends:
+                check_in = user.can_access_check_in(friend)
+                if not check_in:
+                    continue
+                for entry in live_entries_by_friend_id.get(friend.id, []):
+                    fields = component_visibility_fields.get(entry.component)
+                    if not fields:
+                        continue
+                    visibility_field, updated_at_field = fields
+                    if not viewer_sees_check_in_component(
+                        check_in, friend, user, visibility_field, updated_at_field
+                    ):
+                        continue
+                    if not entry_has_content(entry):
+                        continue
+                    prev = latest_entry_updated_at_by_friend_id.get(friend.id)
+                    if prev is None or entry.updated_at > prev:
+                        latest_entry_updated_at_by_friend_id[friend.id] = entry.updated_at
+
+            def latest_check_in_update(friend):
+                return latest_entry_updated_at_by_friend_id.get(friend.id)
+
+            friends_with_updates = [
+                friend for friend in friends
+                if latest_check_in_update(friend) is not None
+            ]
+
+            self._qs = sorted(friends_with_updates, key=latest_check_in_update, reverse=True)
         elif query_type == 'favorites':
             self._qs = user.favorites.all().order_by('username')
         elif query_type == 'hidden':
@@ -1702,7 +1764,7 @@ class FriendList(generics.ListAPIView):
 
     def _build_batch_context(self, ctx, friend_ids):
         from collections import defaultdict
-        from check_in.models import CheckIn, Song, Poke
+        from check_in.models import CheckIn, CheckInComponentEntry, Song, Poke
         from chat.models import ChatRoom, Message
         from note.models import Note
         from qna.models import Response as QnaResponse
@@ -1725,6 +1787,7 @@ class FriendList(generics.ListAPIView):
                 'content_report_keys': set(),
                 'pokes_by_receiver': {},
                 'pinned_count_by_friend_id': {},
+                'live_check_in_entries_by_user_id': {},
             })
             return
 
@@ -1800,6 +1863,17 @@ class FriendList(generics.ListAPIView):
             if _is_audience(ci.user_id, ci.visibility, ci.pk, ct_ci.id, ci.created_at):
                 visible_check_in_by_user_id[ci.user_id] = ci
         ctx['visible_check_in_by_user_id'] = visible_check_in_by_user_id
+
+        live_check_in_entries_by_user_id = defaultdict(dict)
+        live_entries = (
+            CheckInComponentEntry.objects
+            .filter(owner_id__in=friend_ids, superseded_at__isnull=True)
+            .only('owner_id', 'component', 'data', 'visibility', 'updated_at')
+            .order_by('owner_id', 'component', '-created_at')
+        )
+        for entry in live_entries:
+            live_check_in_entries_by_user_id[entry.owner_id].setdefault(entry.component, entry)
+        ctx['live_check_in_entries_by_user_id'] = live_check_in_entries_by_user_id
 
         # 6. Active songs
         ctx['active_song_by_user_id'] = {
@@ -1886,8 +1960,6 @@ class FriendList(generics.ListAPIView):
         # Python, reusing the same helpers that drive the single-user
         # pinned endpoint. Only fields required for the filter are
         # selected so the scan is cheap even for heavy users.
-        from check_in.models import CheckInComponentEntry
-
         pinned_rows = CheckInComponentEntry.objects.filter(
             owner_id__in=friend_ids,
             is_pinned=True,


### PR DESCRIPTION
## Summary
- Add a check_in_updates friend-list query for friend Feed cards
- Source check-in update content and timestamps from live CheckInComponentEntry rows
- Filter query candidates to visible/renderable live entries so superseded A/B updates do not appear when a field changes A -> B -> C

## Side effects checked
- /user/friends/?type=all and close_friends still use the same serializer fields, now aligned with the existing live-entry source used by CheckInBaseSerializer.
- check_in_updates only returns friends with renderable visible live entries, avoiding empty cards and pagination filled by invisible updates.
- Hidden friends remain excluded.

## Verification
- python -m py_compile adoorback/account/views.py adoorback/account/serializers.py