### PR TITLE
Allow unchanged usernames on profile update

### DIFF
--- a/adoorback/account/tests_update_profile.py
+++ b/adoorback/account/tests_update_profile.py
@@ -54,6 +54,32 @@ class UserProfileUpdateTest(TestCase):
         expected_url = f"/users/{new_username}"
         self.assertEqual(noti.redirect_url, expected_url)
 
+    def test_profile_update_accepts_unchanged_username(self):
+        response = self.client.patch(self.url, {
+            'username': self.user.username,
+            'bio': 'Updated bio',
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'old_username')
+        self.assertEqual(self.user.bio, 'Updated bio')
+
+    def test_profile_update_accepts_unchanged_legacy_email_username(self):
+        self.user.username = 'legacy@example.com'
+        self.user.username_history = ['legacy@example.com']
+        self.user.save()
+
+        response = self.client.patch(self.url, {
+            'username': 'legacy@example.com',
+            'bio': 'Updated bio',
+        })
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'legacy@example.com')
+        self.assertEqual(self.user.bio, 'Updated bio')
+
     def test_profile_visibility_update_and_view(self):
         # User updates visibility preferences to 'friends' (per-field 4-way enum)
         update_data = {

--- a/adoorback/account/views.py
+++ b/adoorback/account/views.py
@@ -1158,12 +1158,13 @@ class CurrentUserDetail(generics.RetrieveUpdateAPIView):
             if 'username' in self.request.data:
                 new_username = serializer.validated_data.get('username')
                 old_username = self.request.user.username
-                # check if @ or . is included in username
-                if '@' in new_username or '.' in new_username:
-                    raise InvalidUsername()
-                # check if username exceeds 20 letters
-                if len(new_username) > 20:
-                    raise LongUsername()
+                if new_username != old_username:
+                    # check if @ or . is included in username
+                    if '@' in new_username or '.' in new_username:
+                        raise InvalidUsername()
+                    # check if username exceeds 20 letters
+                    if len(new_username) > 20:
+                        raise LongUsername()
 
             persona_str = self.request.data.get('persona') or self.request.data.get('user_personas')
             interest_str = self.request.data.get('interest') or self.request.data.get('user_interests') or self.request.data.get('user_interest')


### PR DESCRIPTION
## Summary
- Only apply manual username format checks when the submitted username actually changes.
- Add regression coverage for unchanged username saves, including legacy email-shaped usernames.

## Verification
- python -m py_compile adoorback/account/views.py adoorback/account/tests_update_profile.py

## Notes
- Django tests could not run locally because python-dotenv is not installed in the available Python environments.